### PR TITLE
Rename Dockerfile templates

### DIFF
--- a/cli/bblfsh-sdk/cmd/update.go
+++ b/cli/bblfsh-sdk/cmd/update.go
@@ -95,7 +95,7 @@ func (c *UpdateCommand) processTemplateAsset(name string, v interface{}, overwri
 	}
 
 	name = fixGitFolder(name)
-	file := filepath.Join(c.Root, name[:len(name)-len(tplExtension)])
+	file := filepath.Join(c.Root, name)
 
 	buf := bytes.NewBuffer(nil)
 	if err := t.Execute(buf, v); err != nil {


### PR DESCRIPTION
### problem to fix:
The sdk is not generating a `Dockerfile.tpl` nor `Dockerfile.build.tpl` as required by `%lang%-driver/.sdk/make/rules.mk:67`
```
> make test
/bin/sh: 1: eval: cannot open /projects/src/github.com/bblfsh/php-driver/Dockerfile.build.tpl: No such file
/projects/src/github.com/bblfsh/php-driver/.sdk/make/rules.mk:67: recipe for target 'bblfsh/php-driver-build' failed
make: *** [bblfsh/php-driver-build] Error 2
```

### cause
When the SDK processes the template, in order to generate `Dockerfile.tpl` and `Dockerfile.build.tpl` files, the `.tpl` extension is dropped