### PR TITLE
Added ColumnKey to BaseToNoder and load its value into (existing) Node.StartPosition.Col

### DIFF
--- a/uast/tonoder.go
+++ b/uast/tonoder.go
@@ -43,7 +43,7 @@ type BaseToNoder struct {
 	OffsetKey string
 	// LineKey is a key that indicates the line number.
 	LineKey string
-	// ColumnKey is a key that indicated the column inside the line
+	// ColumnKey is a key that indicates the column inside the line
 	ColumnKey string
 	// TokenKeys is a slice of keys used to extract token content.
 	TokenKeys map[string]bool

--- a/uast/tonoder.go
+++ b/uast/tonoder.go
@@ -43,6 +43,8 @@ type BaseToNoder struct {
 	OffsetKey string
 	// LineKey is a key that indicates the line number.
 	LineKey string
+	// ColumnKey is a key that indicated the column inside the line
+	ColumnKey string
 	// TokenKeys is a slice of keys used to extract token content.
 	TokenKeys map[string]bool
 	// SyntheticTokens is a map of InternalType to string used to add
@@ -175,6 +177,13 @@ func (c *BaseToNoder) addProperty(n *Node, k string, o interface{}) error {
 		}
 
 		n.StartPosition.Line = i
+	case c.ColumnKey == k:
+		i, err := toUint32(o)
+		if err != nil {
+			return err
+		}
+
+		n.StartPosition.Col = i
 	default:
 		n.Properties[k] = fmt.Sprint(0)
 	}


### PR DESCRIPTION
Python AST uses line and column, the later was missing from BaseToNoder but was present in the StartPosition struct member of the Node.