### PR TITLE
uast: Delete keyword

### DIFF
--- a/uast/uast.go
+++ b/uast/uast.go
@@ -379,6 +379,7 @@ const (
 
 	Type
 	// TODO: should we distinguish between primitive and builtin types?
+	// TODO: TypeImplements, TypeSuperclasses, etc
 	PrimitiveType
 
 	// Assignment represents a variable assignment or binding.
@@ -404,6 +405,13 @@ const (
 	// (e.g. Java, C++, PHP), `self` (e.g. Smalltalk, Perl, Swift) and `Me`
 	// (e.g. Visual Basic).
 	This
+
+	// Delete for the languages that have it usually deletes a (usually allocated
+	// on the heap) variable, freeing its resources and (usually) calling the
+	// destructors. It needs a child DeleteTarget node which can be an expression
+	// giving as result the instance to be deallocated.
+	Delete
+	DeleteTarget
 
 	Comment
 


### PR DESCRIPTION
This is the delete keyword that unallocates stuff created on the heap and call its destructors on some languages (Python, C++, D, Java, etc). Python also uses it for removing keys from dictionaries.