### PR TITLE
uast: added OpUnpackList and OpUnpackMap

### DIFF
--- a/uast/uast.go
+++ b/uast/uast.go
@@ -243,8 +243,19 @@ const (
 	NumberLiteral
 	TypeLiteral
 
+	// OpUnpackList is the operator used to unpack a sequence type values
+	// to anywhere that can take consecutive values like function calls
+	// or pattern matching (e.g. Python/Groovy/TCL/Ruby "*", Scala ":_*", etc).
+	// It should have a child with the compound type var being unpacked
+	OpUnpackList
+
+	// OpMapUnpack is the operator used to expand maps type values into a series of
+	// key=value arguments. This is usually only useful for using it on
+	// function calls
+	OpUnpackMap
+
 	Type
-	// TODO: should we distinguist between primitive and builtin types?
+	// TODO: should we distinguish between primitive and builtin types?
 	PrimitiveType
 
 	// Assignment represents a variable assignment or binding.


### PR DESCRIPTION
This maps the * and ** features of Python (and many other, usually interpreted, languages) to unpack a list or map into anywhere that expects several comma or k=v-comma separated values (function calls usually).