### PR TITLE
sdk tonoder: listproperty to parent node

### DIFF
--- a/uast/tonoder_test.go
+++ b/uast/tonoder_test.go
@@ -28,6 +28,78 @@ func TestToNoderJava(t *testing.T) {
 	require.NotNil(n)
 }
 
+// Test for promoting a specific property-list elements to its own node
+func TestPropertyListPromotionSpecific(t *testing.T) {
+	require := require.New(t)
+
+	f, err := getFixture("java_example_1.json")
+	require.NoError(err)
+
+	var c ToNoder = &BaseToNoder{
+		InternalTypeKey: "internalClass",
+		LineKey:         "line",
+	}
+	n, err := c.ToNode(f)
+	require.NoError(err)
+	require.NotNil(n)
+
+	child := findChildWithInternalType(n, "CompilationUnit.types")
+	require.Nil(child)
+
+	c = &BaseToNoder{
+		InternalTypeKey: "internalClass",
+		LineKey:         "line",
+		PromotedPropertyLists: map[string]map[string]bool {
+			"CompilationUnit" : { "types" : true },
+		},
+		PromoteAllPropertyLists: false,
+	}
+
+	n, err = c.ToNode(f)
+	require.NoError(err)
+	require.NotNil(n)
+}
+
+// Test promoting all property-list elements to its own node
+func TestPropertyListPromotionAll(t *testing.T) {
+	require := require.New(t)
+
+	f, err := getFixture("java_example_1.json")
+	require.NoError(err)
+
+	var c ToNoder = &BaseToNoder{
+		InternalTypeKey: "internalClass",
+		LineKey:         "line",
+	}
+	n, err := c.ToNode(f)
+	require.NoError(err)
+	require.NotNil(n)
+	child := findChildWithInternalType(n, "CompilationUnit.types")
+	require.Nil(child)
+
+	c = &BaseToNoder{
+		InternalTypeKey: "internalClass",
+		LineKey:         "line",
+		PromoteAllPropertyLists: true,
+	}
+
+	n, err = c.ToNode(f)
+	require.NoError(err)
+	require.NotNil(n)
+
+	child = findChildWithInternalType(n, "CompilationUnit.types")
+	require.NotNil(child)
+}
+
+func findChildWithInternalType(n *Node, internalType string) (*Node) {
+	for _, child := range n.Children {
+		if child.InternalType == internalType {
+			return child
+		}
+	}
+	return nil
+}
+
 func getFixture(name string) (map[string]interface{}, error) {
 	path := filepath.Join(fixtureDir, name)
 	f, err := os.Open(path)

--- a/uast/uast.go
+++ b/uast/uast.go
@@ -172,6 +172,7 @@ const (
 	// specified as the token of the child FunctionDeclarationArgumentName and depending on the language it
 	// could have one or more child nodes of different types to implement them in the UAST like
 	// FunctionDeclarationArgumentDefaultValue, type declarations (TODO), annotations (TODO), etc.
+	//FunctionDeclarationArguments
 	FunctionDeclarationArgument
 	// FunctionDeclarationArgumentName is the symbolic name of the argument. On languages that support
 	// argument passing by name this will be the name used by the CallNamedArgument roles.


### PR DESCRIPTION
This PR adds two settings to allow the translation to promote properties (dictionary keys) with a list value to its own node (aka "property-lists"). Without this PR the nodes in the list will be added as children of the enclosing dictionary with the only reference to the key being the internalRole property so if we have:

```text
{If: { body: [expr, expr, expr],
     test: [exprtest, exprtest],  
     else: [elseexpr, elseexpr]}
}
```

In the UAST we would get:

```text
{If: {Children: [expr, expr, expr, exprtest, exprtest, elseexpr, elseexpr]}}
```
This can work in some cases since the nodes can have multiple roles so a human/machine reading the UAST could still see the type of every nodes, so in this case expr would have the roles Expression and IfBody and the args would have Argument and Arguments, but it's a little different for what most AST do.

This PR allows the UAST translator to define that some of all of these property-lists can be upgraded to have its own node with the values of the list as its Children like:

```text
{If { body: {Children:[expr, expr, expr], 
     test: [exprtest, exprtest], 
     else: [exprelse, exprelse]
}}
```

In this case only the "body" would need to have the IfBody role, the test the IfCondition, etc, tough of course the normalizer programmer could change this as fit.

Please review not only the concept but also the code since I'm still very green to Go lang. I'm also usually bad at naming things so check that too.

Tests are not included tough I've tested it troughfully with my version of the Python driver but I'll add them on this same branch soon.

This sets the internal key of the new promoted nodes to "Parentnode.property" so the new nodes can have rules defined in the normalizer.