### PR TITLE
uast: added roles for BinaryExpressions 

### DIFF
--- a/uast/uast.go
+++ b/uast/uast.go
@@ -29,6 +29,17 @@ const (
 	// or more qualifiers.
 	QualifiedIdentifier
 
+	// BinaryExpression is the parent node of all binary expressions of any type. It must have
+	// BinaryExpressionLeft, BinaryExpressionRight and BinaryExpressionOp children.
+	// Those children must have aditional roles specifying the specific type (e.g. Expression,
+	// QualifiedIdentifier or Literal for the left and right nodes and one of the specific operator roles
+	// for the binary operator). BinaryExpresion can be considered a derivation of Expression and thus
+	// could be its child or implemented as an additional node.
+	BinaryExpression
+	BinaryExpressionLeft
+	BinaryExpressionRight
+	BinaryExpressionOp
+
 	// Binary bitwise operators, used to alterate bits on numeral variables
 
 	// OpBitwiseLeftShift is the binary bitwise shift to the left operator (i.e. << in most languages)


### PR DESCRIPTION
Second try fixing the mess of my previous PR history, reseting my fork master to this one.

Original text:

Adds:

BinaryExpression
BinaryExpressionLeft
BinaryExpressionRight
BinaryExpressionOperator

Usually BinaryExpression would be a parent node while BinaryExpression[Left|Right|Operator] would be additional roles added to the left side, right side and existing operator roles.