### PR TITLE
uast: added FuncionDeclarationArguments role

### DIFF
--- a/uast/uast.go
+++ b/uast/uast.go
@@ -168,9 +168,11 @@ const (
 	FunctionDeclarationName
 	// FunctionDeclarationReceiver is the target Type of a method or struct.
 	FunctionDeclarationReceiver
-	// FunctionDeclarationArgument is the parent node for the function formal arguments. The name will be
-	// specified as the token of the child FunctionDeclarationArgumentName and depending on the language it
-	// could have one or more child nodes of different types to implement them in the UAST like
+	// FunctionDeclarationArguments is the parent node grouping all FuncionDeclarationArgument nodes.
+	FunctionDeclarationArguments
+	// FunctionDeclarationArgument represents and individual formal argument. The name will be specified as the
+	// token of the child FunctionDeclarationArgumentName and depending on the language it could have one or
+	// more child nodes (or aditional roles) of different types to implement them in the UAST like
 	// FunctionDeclarationArgumentDefaultValue, type declarations (TODO), annotations (TODO), etc.
 	FunctionDeclarationArgument
 	// FunctionDeclarationArgumentName is the symbolic name of the argument. On languages that support


### PR DESCRIPTION
*(New PR with non-messed history)*

Micro PR, it adds a grouping node (`FunctionDeclarationArguments`) for function formal parameters (`FunctionDeclarationArgument`). I did a quick check on Python, C++ (cdt) and Nim and all those create a parent node for the formal parameters.

Also updated the doc so its clearer what the singular and plural roles are for.