### PR TITLE
uast: added MapKey and MapValue roles

### DIFF
--- a/uast/uast.go
+++ b/uast/uast.go
@@ -377,6 +377,12 @@ const (
 	// annotations.
 	OtherLiteral
 
+	// MapEntry is the expression pairing a map key and a value usually on MapLiteral expressions. It must
+	// have both a MapKey and a MapValue children (e.g. {"key": "value", "otherkey": "otherval"} in Python).
+	MapEntry
+	MapKey
+	MapValue
+
 	Type
 	// TODO: should we distinguish between primitive and builtin types?
 	PrimitiveType


### PR DESCRIPTION
This complements the MapLiteral UAST role adding MapKey and MapValue.