### PR TITLE
Fix for SyntheticTokens not being translated, unittest added

### DIFF
--- a/uast/tonoder.go
+++ b/uast/tonoder.go
@@ -231,7 +231,17 @@ func (c *BaseToNoder) addProperty(n *Node, k string, o interface{}) error {
 
 		n.Token = s
 	case c.InternalTypeKey == k:
-		// should be already set by toNode
+		// InternalType should be already set by toNode, but check if
+		// they InternalKey is one of the ones in SyntheticTokens.
+		s := fmt.Sprint(o)
+		tk := c.syntheticToken(s)
+		if tk != "" {
+			if n.Token != "" && n.Token != tk {
+				return ErrTwoTokensSameNode.New(n.Token, tk)
+			}
+
+			n.Token = tk
+ 		}
 		return nil
 	case c.OffsetKey == k:
 		i, err := toUint32(o)

--- a/uast/tonoder_test.go
+++ b/uast/tonoder_test.go
@@ -188,6 +188,32 @@ func TestPropertyListPromotionAll(t *testing.T) {
 	require.NotNil(child)
 }
 
+func TestSyntheticTokens(t *testing.T) {
+	require := require.New(t)
+
+	f, err := getFixture("java_example_1.json")
+	require.NoError(err)
+
+	var c ToNoder = &BaseToNoder{
+		InternalTypeKey: "internalClass",
+		LineKey:         "line",
+		SyntheticTokens: map[string]string{
+			"CompilationUnit": "TestToken",
+		},
+	}
+	n, err := c.ToNode(f)
+	require.NoError(err)
+	require.NotNil(n)
+	child := findChildWithInternalType(n, "CompilationUnit")
+
+	require.Nil(child)
+	n, err = c.ToNode(f)
+	require.NoError(err)
+	require.NotNil(n)
+	require.True(n.Token == "TestToken")
+
+}
+
 func findChildWithInternalType(n *Node, internalType string) *Node {
 	for _, child := range n.Children {
 		if child.InternalType == internalType {


### PR DESCRIPTION
This fix a bugfix that I introduced some commits ago which caused the SyntheticTokens not being translated. It also adds a unittest to detect this problem in the future.