### PR TITLE
Added function for cyclomatic complexity + unittest

### DIFF
--- a/uast/uast_test.go
+++ b/uast/uast_test.go
@@ -9,7 +9,7 @@ import (
 func TestPrefixTokens(t *testing.T) {
 	require := require.New(t)
 
-	n := &Node{InternalType: "empty",
+	n := &Node{InternalType: "module",
 		Children: []*Node{
 			{InternalType: "id", Token: "id3"},
 			// Prefix is the default so it doesnt need any role
@@ -25,7 +25,7 @@ func TestPrefixTokens(t *testing.T) {
 func TestPrefixTokensSubtree(t *testing.T) {
 	require := require.New(t)
 
-	n := &Node{InternalType: "empty",
+	n := &Node{InternalType: "module",
 		Children: []*Node{
 			{InternalType: "id", Token: "id3"},
 			// Prefix is the default so it doesnt need any role
@@ -53,7 +53,7 @@ func TestPrefixTokensSubtree(t *testing.T) {
 func TestPrefixTokensPlain(t *testing.T) {
 	require := require.New(t)
 
-	n := &Node{InternalType: "empty",
+	n := &Node{InternalType: "module",
 		Children: []*Node{
 			{InternalType: "id", Token: "id3"},
 			// Prefix is the default so it doesnt need any role
@@ -68,7 +68,7 @@ func TestPrefixTokensPlain(t *testing.T) {
 
 func TestInfixTokens(t *testing.T) {
 	require := require.New(t)
-	n := &Node{InternalType: "empty",
+	n := &Node{InternalType: "module",
 		Children: []*Node{
 			{InternalType: "id", Token: "id1"},
 			{InternalType: "op_infix", Roles: []Role{Infix}, Token: "Infix+", Children: []*Node{
@@ -83,7 +83,7 @@ func TestInfixTokens(t *testing.T) {
 func TestInfixTokensSubtree(t *testing.T) {
 	require := require.New(t)
 
-	n := &Node{InternalType: "empty",
+	n := &Node{InternalType: "module",
 		Children: []*Node{
 			{InternalType: "id3", Token: "id3"},
 			// Prefix is the default so it doesnt need any role
@@ -110,7 +110,7 @@ func TestInfixTokensSubtree(t *testing.T) {
 
 func TestInfixTokensPlain(t *testing.T) {
 	require := require.New(t)
-	n := &Node{InternalType: "empty",
+	n := &Node{InternalType: "module",
 		Children: []*Node{
 			{InternalType: "id", Token: "id1"},
 			{InternalType: "left", Token: "tok_in_left"},
@@ -124,7 +124,7 @@ func TestInfixTokensPlain(t *testing.T) {
 
 func TestPostfixTokens(t *testing.T) {
 	require := require.New(t)
-	n := &Node{InternalType: "empty",
+	n := &Node{InternalType: "module",
 		Children: []*Node{
 			{InternalType: "id", Token: "id2"},
 			{InternalType: "op_postfix", Roles: []Role{Postfix}, Token: "Postfix+", Children: []*Node{
@@ -139,7 +139,7 @@ func TestPostfixTokens(t *testing.T) {
 func TestPostfixTokensSubtree(t *testing.T) {
 	require := require.New(t)
 
-	n := &Node{InternalType: "empty",
+	n := &Node{InternalType: "module",
 		Children: []*Node{
 			{InternalType: "id", Token: "id2"},
 			// Prefix is the default so it doesnt need any role
@@ -165,7 +165,7 @@ func TestPostfixTokensSubtree(t *testing.T) {
 
 func TestPostfixTokensPlain(t *testing.T) {
 	require := require.New(t)
-	n := &Node{InternalType: "empty",
+	n := &Node{InternalType: "module",
 		Children: []*Node{
 			{InternalType: "id", Token: "id2"},
 			{InternalType: "left", Token: "tok_post_left"},
@@ -181,7 +181,7 @@ func TestPostfixTokensPlain(t *testing.T) {
 func TestOrderTokens(t *testing.T) {
 	require := require.New(t)
 
-	n := &Node{InternalType: "empty",
+	n := &Node{InternalType: "module",
 		Children: []*Node{
 			{InternalType: "id", Token: "id1"},
 			{InternalType: "op_infix", Roles: []Role{Infix}, Token: "Infix+", Children: []*Node{
@@ -216,4 +216,28 @@ func TestOrderTokens(t *testing.T) {
 		"id2", "tok_post_left", "tok_post_right", "subright_pre1", "subright_pre2", "Postfix+",
 		"id3", "Prefix+", "tok_pre_left", "subright_in1", "tok_pre_right", "subright_in2"}
 	require.Equal(expected, result)
+}
+
+func TestCyclomaticComplexity(t *testing.T) {
+	require := require.New(t)
+	n := &Node{InternalType: "module",
+		Children: []*Node{
+			{InternalType: "root"}, // 1 (initial)
+			// Prefix is the default so it doesnt need any role
+			{InternalType: "if1", Roles: []Role{If}, Children: []*Node{  // 2 (If)
+				{InternalType: "if1else1", Roles: []Role{IfElse}, Children: []*Node{ // 0
+					{InternalType: "if1else1foreach", Roles: []Role{ForEach}, Children: []*Node{ // 3 (ForEach)
+						{InternalType: "foreach_child1"}, // 0
+						{InternalType: "foreach_child2_continue", Roles: []Role{Continue}}, // 4 (Continue)
+					}},
+					{InternalType: "if1else1if", Roles: []Role{If}, Children: []*Node{ // 5 (If)
+						{InternalType: "elseif_child1"}, // 0
+						{InternalType: "opAnd", Roles: []Role{OpBooleanAnd}}, // 6 (OpBooleanAnd)
+						{InternalType: "elseif_child2"}, // 0
+					}},
+				}},
+				{InternalType: "break", Roles: []Role{Break}},
+			},
+			}}}
+	require.Equal(CyclomaticComplexity(n), 6)
 }

--- a/uast/utils.go
+++ b/uast/utils.go
@@ -18,7 +18,12 @@ func Tokens(n *Node) []string {
 	return tokens
 }
 
-// CyclomaticComplexity returns the cyclomatic complexity for the node. This uses the method of
+// CyclomaticComplexity returns the cyclomatic complexity for the node. The cyclomatic complexity
+// is a quantitative measure of the number of linearly independent paths through a program's source code.
+// It was developed by Thomas J. McCabe, Sr. in 1976. For a formal description see:
+// https://en.wikipedia.org/wiki/Cyclomatic_complexity
+// And the original paper: http://www.literateprogramming.com/mccabe.pdf
+// This implementation uses the method of
 // counting one + one of the following UAST Roles if present on any children:
 // If | SwitchCase |  SwitchDefault | For[Each] | [Do]While | TryCatch | Continue | OpBoolean* | Goto
 // Important: since some languages allow for code defined
@@ -27,7 +32,6 @@ func Tokens(n *Node) []string {
 // If the children contain more than one function definitions, the value will not be averaged between
 // the total number of function declarations but given as a total.
 //
-// Original paper: http://www.literateprogramming.com/mccabe.pdf
 //
 // Some practical implementations counting tokens in the code. They sometimes differ; for example
 // some of them count the switch "default" as an incrementor, some consider all return values minus the

--- a/uast/utils.go
+++ b/uast/utils.go
@@ -32,16 +32,26 @@ func Tokens(n *Node) []string {
 // If the children contain more than one function definitions, the value will not be averaged between
 // the total number of function declarations but given as a total.
 //
-//
 // Some practical implementations counting tokens in the code. They sometimes differ; for example
 // some of them count the switch "default" as an incrementor, some consider all return values minus the
 // last, some of them consider "else" (which is wrong IMHO, but not for elifs, remember than the IfElse
 // token in the UAST is really an Else not an "else if", elseifs would have a children If token), some
 // consider throw and finally while others only the catch, etc.
 //
+// Examples:
 // GMetrics: http://gmetrics.sourceforge.net/gmetrics-CyclomaticComplexityMetric.html
 // Go: https://github.com/fzipp/gocyclo/blob/master/gocyclo.go#L214
 // SonarQube (include rules for many languages): https://docs.sonarqube.org/display/SONAR/Metrics+-+Complexity
+//
+// IMPORTANT DISCLAIMER: McCabe definition specifies clearly that boolean operations should increment the
+// count in 1 for every boolean element when the language if the language evaluates conditions in
+// short-circuit.  Unfortunately in the current version of the UAST we don't specify these language invariants
+// and also we still haven't defined how we are going to represent the boolean expressions (which also would
+// need a tree transformation process in the pipeline that we lack) so lacking a better way of detecting for
+// all  languages what symbols or literals are part of a boolean expression we count the boolean operators
+// themselves which should work for short-circuit infix languages but not prefix or infix languages that can
+// evaluate more than two items with a single operator.  (FIXME when both things are solved in the UAST
+// definition and the SDK).
 func CyclomaticComplexity(n *Node)  int {
 	complx := 1
 

--- a/uast/utils.go
+++ b/uast/utils.go
@@ -17,3 +17,46 @@ func Tokens(n *Node) []string {
 	}
 	return tokens
 }
+
+// CyclomaticComplexity returns the cyclomatic complexity for the node. This uses the method of
+// counting one + one of the following UAST Roles if present on any children:
+// If | SwitchCase |  SwitchDefault | For[Each] | [Do]While | TryCatch | Continue | OpBoolean* | Goto
+// Important: since some languages allow for code defined
+// outside function definitions, this won't check that the Node has the role FunctionDeclarationRole
+// so the user should check that if the intended use is calculating the complexity of a function/method.
+// If the children contain more than one function definitions, the value will not be averaged between
+// the total number of function declarations but given as a total.
+//
+// Original paper: http://www.literateprogramming.com/mccabe.pdf
+//
+// Some practical implementations counting tokens in the code. They sometimes differ; for example
+// some of them count the switch "default" as an incrementor, some consider all return values minus the
+// last, some of them consider "else" (which is wrong IMHO, but not for elifs, remember than the IfElse
+// token in the UAST is really an Else not an "else if", elseifs would have a children If token), some
+// consider throw and finally while others only the catch, etc.
+//
+// GMetrics: http://gmetrics.sourceforge.net/gmetrics-CyclomaticComplexityMetric.html
+// Go: https://github.com/fzipp/gocyclo/blob/master/gocyclo.go#L214
+// SonarQube (include rules for many languages): https://docs.sonarqube.org/display/SONAR/Metrics+-+Complexity
+func CyclomaticComplexity(n *Node)  int {
+	complx := 1
+
+	iter := NewOrderPathIter(NewPath(n))
+
+	for {
+		p := iter.Next()
+		if p.IsEmpty() {
+			break
+		}
+		n := p.Node()
+		for _, r := range n.Roles {
+			switch(r) {
+			case If, SwitchCase, SwitchDefault, For, ForEach, While,
+			     DoWhile, TryCatch, Continue, OpBooleanAnd, OpBooleanOr,
+			     OpBooleanXor:
+				complx++
+			}
+		}
+	}
+	return complx
+}

--- a/uast/utils.go
+++ b/uast/utils.go
@@ -23,9 +23,10 @@ func Tokens(n *Node) []string {
 // It was developed by Thomas J. McCabe, Sr. in 1976. For a formal description see:
 // https://en.wikipedia.org/wiki/Cyclomatic_complexity
 // And the original paper: http://www.literateprogramming.com/mccabe.pdf
-// This implementation uses the method of
+
+// This implementation uses PMD implementation as reference and uses the method of
 // counting one + one of the following UAST Roles if present on any children:
-// If | SwitchCase |  SwitchDefault | For[Each] | [Do]While | TryCatch | Continue | OpBoolean* | Goto
+// If | SwitchCase |  For[Each] | [Do]While | TryCatch | Continue | OpBoolean* | Goto
 // Important: since some languages allow for code defined
 // outside function definitions, this won't check that the Node has the role FunctionDeclarationRole
 // so the user should check that if the intended use is calculating the complexity of a function/method.
@@ -39,6 +40,7 @@ func Tokens(n *Node) []string {
 // consider throw and finally while others only the catch, etc.
 //
 // Examples:
+// PMD reference implementation: http://pmd.sourceforge.net/pmd-4.3.0/xref/net/sourceforge/pmd/rules/CyclomaticComplexity.html
 // GMetrics: http://gmetrics.sourceforge.net/gmetrics-CyclomaticComplexityMetric.html
 // Go: https://github.com/fzipp/gocyclo/blob/master/gocyclo.go#L214
 // SonarQube (include rules for many languages): https://docs.sonarqube.org/display/SONAR/Metrics+-+Complexity
@@ -65,7 +67,7 @@ func CyclomaticComplexity(n *Node)  int {
 		n := p.Node()
 		for _, r := range n.Roles {
 			switch(r) {
-			case If, SwitchCase, SwitchDefault, For, ForEach, While,
+			case If, SwitchCase, For, ForEach, While,
 			     DoWhile, TryCatch, Continue, OpBooleanAnd, OpBooleanOr,
 			     OpBooleanXor:
 				complx++


### PR DESCRIPTION
This adds uast.utils.CyclomaticComplexity that for a given Node (and children) will calculate the cyclomatic complexity. Also adds a unittest.

This doesn't include the NPath complexity.