### PR TITLE
update to go-errors migration to gopkg.in

### DIFF
--- a/protocol/driver/server.go
+++ b/protocol/driver/server.go
@@ -6,7 +6,7 @@ import (
 	"github.com/bblfsh/sdk/protocol"
 	"github.com/bblfsh/sdk/protocol/jsonlines"
 
-	"srcd.works/go-errors.v0"
+	"gopkg.in/src-d/go-errors.v0"
 )
 
 var (

--- a/protocol/native/objecttonoder.go
+++ b/protocol/native/objecttonoder.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/bblfsh/sdk/uast"
 
-	"srcd.works/go-errors.v0"
+	"gopkg.in/src-d/go-errors.v0"
 )
 
 var (

--- a/uast/ann/ann_test.go
+++ b/uast/ann/ann_test.go
@@ -3,7 +3,7 @@ package ann
 import (
 	"testing"
 
-	errors "srcd.works/go-errors.v0"
+	errors "gopkg.in/src-d/go-errors.v0"
 
 	. "github.com/bblfsh/sdk/uast"
 


### PR DESCRIPTION
Merge https://github.com/src-d/go-errors/pull/6 first.

Part of https://github.com/src-d/backlog/issues/700.