### PR TITLE
add driver.Client to communicate with drivers

### DIFF
--- a/protocol/driver/client.go
+++ b/protocol/driver/client.go
@@ -1,0 +1,40 @@
+package driver
+
+import (
+	"io"
+
+	"github.com/bblfsh/sdk/protocol"
+	"github.com/bblfsh/sdk/protocol/jsonlines"
+)
+
+// Client is a client to communicate with a driver.
+type Client struct {
+	closer io.Closer
+	enc    jsonlines.Encoder
+	dec    jsonlines.Decoder
+}
+
+func NewClient(in io.WriteCloser, out io.Reader) *Client {
+	return &Client{
+		closer: in,
+		enc:    jsonlines.NewEncoder(in),
+		dec:    jsonlines.NewDecoder(out),
+	}
+}
+
+func (c *Client) ParseUAST(req *protocol.ParseUASTRequest) *protocol.ParseUASTResponse {
+	if err := c.enc.Encode(req); err != nil {
+		return newFatalResponse(err)
+	}
+
+	resp := &protocol.ParseUASTResponse{}
+	if err := c.dec.Decode(resp); err != nil {
+		return newFatalResponse(err)
+	}
+
+	return resp
+}
+
+func (c *Client) Close() error {
+	return c.closer.Close()
+}


### PR DESCRIPTION
Added a convenience interface to communicate with bblfsh drivers directly. This will be used by bblfsh/server but might be used separately.