### PR TITLE
driver: do not return error on ParseUAST

### DIFF
--- a/assets/skeleton/bindata.go
+++ b/assets/skeleton/bindata.go
@@ -988,10 +988,10 @@ var build string
 
 func main() {
 	d := driver.Driver{
-		Version:          version,
-		Build:            build,
-		ASTParserBuilder: normalizer.ASTParserBuilder,
-		Annotate:         normalizer.AnnotationRules,
+		Version:           version,
+		Build:             build,
+		UASTParserBuilder: normalizer.UASTParserBuilder,
+		Annotate:          normalizer.AnnotationRules,
 	}
 	d.Exec()
 }
@@ -1007,7 +1007,7 @@ func driverMainGoTpl() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "driver/main.go.tpl", size: 377, mode: os.FileMode(420), modTime: time.Unix(1, 0)}
+	info := bindataFileInfo{name: "driver/main.go.tpl", size: 382, mode: os.FileMode(420), modTime: time.Unix(1, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -1045,8 +1045,8 @@ import (
 	"github.com/bblfsh/sdk/protocol/native"
 )
 
-// ASTParserBuilder creates a parser that transform source code files into *uast.Node.
-func ASTParserBuilder(opts driver.ASTParserOptions) (driver.ASTParser, error) {
+// UASTParserBuilder creates a parser that transform source code files into *uast.Node.
+func UASTParserBuilder(opts driver.UASTParserOptions) (driver.UASTParser, error) {
 	toNoder := &native.ObjectToNoder{}
 	parser, err := native.ExecParser(toNoder, opts.NativeBin)
 	if err != nil {
@@ -1067,7 +1067,7 @@ func driverNormalizerParserGo() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "driver/normalizer/parser.go", size: 437, mode: os.FileMode(420), modTime: time.Unix(1, 0)}
+	info := bindataFileInfo{name: "driver/normalizer/parser.go", size: 441, mode: os.FileMode(420), modTime: time.Unix(1, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }

--- a/etc/skeleton/driver/main.go.tpl
+++ b/etc/skeleton/driver/main.go.tpl
@@ -11,10 +11,10 @@ var build string
 
 func main() {
 	d := driver.Driver{
-		Version:          version,
-		Build:            build,
-		ASTParserBuilder: normalizer.ASTParserBuilder,
-		Annotate:         normalizer.AnnotationRules,
+		Version:           version,
+		Build:             build,
+		UASTParserBuilder: normalizer.UASTParserBuilder,
+		Annotate:          normalizer.AnnotationRules,
 	}
 	d.Exec()
 }

--- a/etc/skeleton/driver/normalizer/parser.go
+++ b/etc/skeleton/driver/normalizer/parser.go
@@ -5,8 +5,8 @@ import (
 	"github.com/bblfsh/sdk/protocol/native"
 )
 
-// ASTParserBuilder creates a parser that transform source code files into *uast.Node.
-func ASTParserBuilder(opts driver.ASTParserOptions) (driver.ASTParser, error) {
+// UASTParserBuilder creates a parser that transform source code files into *uast.Node.
+func UASTParserBuilder(opts driver.UASTParserOptions) (driver.UASTParser, error) {
 	toNoder := &native.ObjectToNoder{}
 	parser, err := native.ExecParser(toNoder, opts.NativeBin)
 	if err != nil {

--- a/protocol/driver/driver.go
+++ b/protocol/driver/driver.go
@@ -2,6 +2,7 @@ package driver
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"io/ioutil"
@@ -201,11 +202,7 @@ func (c *parseUASTCommand) Execute(args []string) error {
 		Annotation: c.Driver.Annotate,
 	}
 
-	resp, err := up.ParseUAST(&protocol.ParseUASTRequest{Content: string(b)})
-	if err != nil {
-		return err
-	}
-
+	resp := up.ParseUAST(&protocol.ParseUASTRequest{Content: string(b)})
 	return fmter(c.Out, resp)
 }
 
@@ -272,9 +269,9 @@ func (c *tokenizeCommand) Execute(args []string) error {
 		Annotation: c.Driver.Annotate,
 	}
 
-	resp, err := up.ParseUAST(&protocol.ParseUASTRequest{Content: string(b)})
-	if err != nil {
-		return err
+	resp := up.ParseUAST(&protocol.ParseUASTRequest{Content: string(b)})
+	if resp.Status == protocol.Fatal {
+		return errors.New("parsing error")
 	}
 
 	toks := uast.Tokens(resp.UAST)

--- a/protocol/driver/driver.go
+++ b/protocol/driver/driver.go
@@ -22,8 +22,8 @@ type Driver struct {
 	Version string
 	// Build identifier.
 	Build string
-	// ASTParserBuilder creates a ASTParser.
-	ASTParserBuilder ASTParserBuilder
+	// UASTParserBuilder creates a ASTParser.
+	UASTParserBuilder UASTParserBuilder
 	// Annotate contains an *ann.Rule to convert AST to UAST.
 	Annotate *ann.Rule
 	// In is the input of the driver. Defaults to os.Stdin.
@@ -89,7 +89,7 @@ func (d *Driver) initialize() {
 
 type cmd struct {
 	*Driver
-	ASTParserOptions
+	UASTParserOptions
 }
 
 type serveCommand struct {
@@ -97,7 +97,7 @@ type serveCommand struct {
 }
 
 func (c *serveCommand) Execute(args []string) error {
-	p, err := c.ASTParserBuilder(c.ASTParserOptions)
+	p, err := c.UASTParserBuilder(c.UASTParserOptions)
 	if err != nil {
 		return err
 	}
@@ -105,8 +105,8 @@ func (c *serveCommand) Execute(args []string) error {
 	server := &Server{
 		In:  c.In,
 		Out: c.Out,
-		UASTParser: &uastParser{
-			ASTParser:  p,
+		UASTParser: &annotationParser{
+			UASTParser: p,
 			Annotation: c.Driver.Annotate,
 		},
 	}
@@ -189,15 +189,15 @@ func (c *parseUASTCommand) Execute(args []string) error {
 		return fmt.Errorf("error reading file %s: %s", f, err.Error())
 	}
 
-	p, err := c.ASTParserBuilder(c.ASTParserOptions)
+	p, err := c.UASTParserBuilder(c.UASTParserOptions)
 	if err != nil {
 		return err
 	}
 
 	defer func() { _ = p.Close() }()
 
-	up := &uastParser{
-		ASTParser:  p,
+	up := &annotationParser{
+		UASTParser: p,
 		Annotation: c.Driver.Annotate,
 	}
 
@@ -260,15 +260,15 @@ func (c *tokenizeCommand) Execute(args []string) error {
 		return fmt.Errorf("error reading file %s: %s", f, err.Error())
 	}
 
-	p, err := c.ASTParserBuilder(c.ASTParserOptions)
+	p, err := c.UASTParserBuilder(c.UASTParserOptions)
 	if err != nil {
 		return err
 	}
 
 	defer func() { _ = p.Close() }()
 
-	up := &uastParser{
-		ASTParser:  p,
+	up := &annotationParser{
+		UASTParser: p,
 		Annotation: c.Driver.Annotate,
 	}
 

--- a/protocol/driver/driver_test.go
+++ b/protocol/driver/driver_test.go
@@ -20,13 +20,13 @@ func testDriver(t *testing.T, args []string, expectedErr bool, expectedStdout, e
 	stderr := bytes.NewBuffer(nil)
 
 	d := &Driver{
-		Version:          "test",
-		Build:            "test",
-		ASTParserBuilder: normalizer.ASTParserBuilder,
-		Annotate:         ann.On(ann.Any).Roles(uast.SimpleIdentifier),
-		In:               stdin,
-		Out:              stdout,
-		Err:              stderr,
+		Version:           "test",
+		Build:             "test",
+		UASTParserBuilder: normalizer.UASTParserBuilder,
+		Annotate:          ann.On(ann.Any).Roles(uast.SimpleIdentifier),
+		In:                stdin,
+		Out:               stdout,
+		Err:               stderr,
 	}
 
 	err := d.Run(args)

--- a/protocol/driver/parser_test.go
+++ b/protocol/driver/parser_test.go
@@ -10,19 +10,6 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-type mockASTParser struct {
-	Response *protocol.ParseASTResponse
-	Error    error
-}
-
-func (p *mockASTParser) ParseAST(req *protocol.ParseASTRequest) (*protocol.ParseASTResponse, error) {
-	return p.Response, p.Error
-}
-
-func (p *mockASTParser) Close() error {
-	return nil
-}
-
 type mockUASTParser struct {
 	Response *protocol.ParseUASTResponse
 	Error    error
@@ -36,45 +23,45 @@ func (p *mockUASTParser) Close() error {
 	return nil
 }
 
-func TestTransformationASTParserUnderlyingError(t *testing.T) {
+func TestTransformationUASTParserUnderlyingError(t *testing.T) {
 	require := require.New(t)
 
 	e := errors.New("test error")
-	p := &mockASTParser{Error: e}
+	p := &mockUASTParser{Error: e}
 	tf := func(d []byte, n *uast.Node) error { return nil }
-	tp := &TransformationASTParser{ASTParser: p, Transformation: tf}
+	tp := &TransformationUASTParser{UASTParser: p, Transformation: tf}
 
-	resp, err := tp.ParseAST(&protocol.ParseASTRequest{Content: "foo"})
+	resp, err := tp.ParseUAST(&protocol.ParseUASTRequest{Content: "foo"})
 	require.Equal(e, err)
 	require.Nil(resp)
 }
 
-func TestTransformationASTParserTransformationError(t *testing.T) {
+func TestTransformationUASTParserTransformationError(t *testing.T) {
 	require := require.New(t)
 
 	e := errors.New("test error")
-	p := &mockASTParser{Response: &protocol.ParseASTResponse{Status: protocol.Ok}}
+	p := &mockUASTParser{Response: &protocol.ParseUASTResponse{Status: protocol.Ok}}
 	tf := func(d []byte, n *uast.Node) error { return e }
-	tp := &TransformationASTParser{ASTParser: p, Transformation: tf}
+	tp := &TransformationUASTParser{UASTParser: p, Transformation: tf}
 
-	resp, err := tp.ParseAST(&protocol.ParseASTRequest{Content: "foo"})
+	resp, err := tp.ParseUAST(&protocol.ParseUASTRequest{Content: "foo"})
 	require.Equal(e, err)
 	require.NotNil(resp)
 }
 
-func TestTransformationASTParser(t *testing.T) {
+func TestTransformationUASTParser(t *testing.T) {
 	require := require.New(t)
 
-	p := &mockASTParser{Response: &protocol.ParseASTResponse{Status: protocol.Ok, AST: &uast.Node{}}}
+	p := &mockUASTParser{Response: &protocol.ParseUASTResponse{Status: protocol.Ok, UAST: &uast.Node{}}}
 	tf := func(d []byte, n *uast.Node) error {
 		n.InternalType = "foo"
 		return nil
 	}
-	tp := &TransformationASTParser{ASTParser: p, Transformation: tf}
+	tp := &TransformationUASTParser{UASTParser: p, Transformation: tf}
 
-	resp, err := tp.ParseAST(&protocol.ParseASTRequest{Content: "foo"})
+	resp, err := tp.ParseUAST(&protocol.ParseUASTRequest{Content: "foo"})
 	require.NoError(err)
 	require.NotNil(resp)
-	require.NotNil(resp.AST)
-	require.Equal("foo", resp.AST.InternalType)
+	require.NotNil(resp.UAST)
+	require.Equal("foo", resp.UAST.InternalType)
 }

--- a/protocol/driver/positions_test.go
+++ b/protocol/driver/positions_test.go
@@ -3,8 +3,8 @@ package driver
 import (
 	"testing"
 
-	"github.com/stretchr/testify/require"
 	"github.com/bblfsh/sdk/uast"
+	"github.com/stretchr/testify/require"
 )
 
 func TestFillLineColFromOffset(t *testing.T) {

--- a/protocol/driver/server.go
+++ b/protocol/driver/server.go
@@ -68,9 +68,9 @@ func (s *Server) process(enc jsonlines.Encoder, dec jsonlines.Decoder) error {
 		return s.error(enc, ErrDecodingRequest.Wrap(err))
 	}
 
-	resp, err := s.UASTParser.ParseUAST(req)
-	if err != nil {
-		return ErrFatalParsing.Wrap(err)
+	resp := s.UASTParser.ParseUAST(req)
+	if resp.Status == protocol.Fatal {
+		return ErrFatalParsing.New()
 	}
 
 	if err := enc.Encode(resp); err != nil {

--- a/protocol/generated.pb.go
+++ b/protocol/generated.pb.go
@@ -9,8 +9,6 @@
 		github.com/bblfsh/sdk/protocol/generated.proto
 
 	It has these top-level messages:
-		ParseASTRequest
-		ParseASTResponse
 		ParseUASTRequest
 		ParseUASTResponse
 */
@@ -54,29 +52,17 @@ var Status_value = map[string]int32{
 
 func (Status) EnumDescriptor() ([]byte, []int) { return fileDescriptorGenerated, []int{0} }
 
-func (m *ParseASTRequest) Reset()                    { *m = ParseASTRequest{} }
-func (m *ParseASTRequest) String() string            { return proto.CompactTextString(m) }
-func (*ParseASTRequest) ProtoMessage()               {}
-func (*ParseASTRequest) Descriptor() ([]byte, []int) { return fileDescriptorGenerated, []int{0} }
-
-func (m *ParseASTResponse) Reset()                    { *m = ParseASTResponse{} }
-func (m *ParseASTResponse) String() string            { return proto.CompactTextString(m) }
-func (*ParseASTResponse) ProtoMessage()               {}
-func (*ParseASTResponse) Descriptor() ([]byte, []int) { return fileDescriptorGenerated, []int{1} }
-
 func (m *ParseUASTRequest) Reset()                    { *m = ParseUASTRequest{} }
 func (m *ParseUASTRequest) String() string            { return proto.CompactTextString(m) }
 func (*ParseUASTRequest) ProtoMessage()               {}
-func (*ParseUASTRequest) Descriptor() ([]byte, []int) { return fileDescriptorGenerated, []int{2} }
+func (*ParseUASTRequest) Descriptor() ([]byte, []int) { return fileDescriptorGenerated, []int{0} }
 
 func (m *ParseUASTResponse) Reset()                    { *m = ParseUASTResponse{} }
 func (m *ParseUASTResponse) String() string            { return proto.CompactTextString(m) }
 func (*ParseUASTResponse) ProtoMessage()               {}
-func (*ParseUASTResponse) Descriptor() ([]byte, []int) { return fileDescriptorGenerated, []int{3} }
+func (*ParseUASTResponse) Descriptor() ([]byte, []int) { return fileDescriptorGenerated, []int{1} }
 
 func init() {
-	proto.RegisterType((*ParseASTRequest)(nil), "github.com.bblfsh.sdk.protocol.ParseASTRequest")
-	proto.RegisterType((*ParseASTResponse)(nil), "github.com.bblfsh.sdk.protocol.ParseASTResponse")
 	proto.RegisterType((*ParseUASTRequest)(nil), "github.com.bblfsh.sdk.protocol.ParseUASTRequest")
 	proto.RegisterType((*ParseUASTResponse)(nil), "github.com.bblfsh.sdk.protocol.ParseUASTResponse")
 	proto.RegisterEnum("github.com.bblfsh.sdk.protocol.Status", Status_name, Status_value)
@@ -93,8 +79,6 @@ const _ = grpc.SupportPackageIsVersion4
 // Client API for ProtocolService service
 
 type ProtocolServiceClient interface {
-	// ParseAST uses DefaultParser to process the given AST parsing request.
-	ParseAST(ctx context.Context, in *ParseASTRequest, opts ...grpc.CallOption) (*ParseASTResponse, error)
 	// ParseUAST uses DefaultParser to process the given UAST parsing request.
 	ParseUAST(ctx context.Context, in *ParseUASTRequest, opts ...grpc.CallOption) (*ParseUASTResponse, error)
 }
@@ -105,15 +89,6 @@ type protocolServiceClient struct {
 
 func NewProtocolServiceClient(cc *grpc.ClientConn) ProtocolServiceClient {
 	return &protocolServiceClient{cc}
-}
-
-func (c *protocolServiceClient) ParseAST(ctx context.Context, in *ParseASTRequest, opts ...grpc.CallOption) (*ParseASTResponse, error) {
-	out := new(ParseASTResponse)
-	err := grpc.Invoke(ctx, "/github.com.bblfsh.sdk.protocol.ProtocolService/ParseAST", in, out, c.cc, opts...)
-	if err != nil {
-		return nil, err
-	}
-	return out, nil
 }
 
 func (c *protocolServiceClient) ParseUAST(ctx context.Context, in *ParseUASTRequest, opts ...grpc.CallOption) (*ParseUASTResponse, error) {
@@ -128,32 +103,12 @@ func (c *protocolServiceClient) ParseUAST(ctx context.Context, in *ParseUASTRequ
 // Server API for ProtocolService service
 
 type ProtocolServiceServer interface {
-	// ParseAST uses DefaultParser to process the given AST parsing request.
-	ParseAST(context.Context, *ParseASTRequest) (*ParseASTResponse, error)
 	// ParseUAST uses DefaultParser to process the given UAST parsing request.
 	ParseUAST(context.Context, *ParseUASTRequest) (*ParseUASTResponse, error)
 }
 
 func RegisterProtocolServiceServer(s *grpc.Server, srv ProtocolServiceServer) {
 	s.RegisterService(&_ProtocolService_serviceDesc, srv)
-}
-
-func _ProtocolService_ParseAST_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
-	in := new(ParseASTRequest)
-	if err := dec(in); err != nil {
-		return nil, err
-	}
-	if interceptor == nil {
-		return srv.(ProtocolServiceServer).ParseAST(ctx, in)
-	}
-	info := &grpc.UnaryServerInfo{
-		Server:     srv,
-		FullMethod: "/github.com.bblfsh.sdk.protocol.ProtocolService/ParseAST",
-	}
-	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
-		return srv.(ProtocolServiceServer).ParseAST(ctx, req.(*ParseASTRequest))
-	}
-	return interceptor(ctx, in, info, handler)
 }
 
 func _ProtocolService_ParseUAST_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
@@ -179,88 +134,12 @@ var _ProtocolService_serviceDesc = grpc.ServiceDesc{
 	HandlerType: (*ProtocolServiceServer)(nil),
 	Methods: []grpc.MethodDesc{
 		{
-			MethodName: "ParseAST",
-			Handler:    _ProtocolService_ParseAST_Handler,
-		},
-		{
 			MethodName: "ParseUAST",
 			Handler:    _ProtocolService_ParseUAST_Handler,
 		},
 	},
 	Streams:  []grpc.StreamDesc{},
 	Metadata: "github.com/bblfsh/sdk/protocol/generated.proto",
-}
-
-func (m *ParseASTRequest) Marshal() (dAtA []byte, err error) {
-	size := m.ProtoSize()
-	dAtA = make([]byte, size)
-	n, err := m.MarshalTo(dAtA)
-	if err != nil {
-		return nil, err
-	}
-	return dAtA[:n], nil
-}
-
-func (m *ParseASTRequest) MarshalTo(dAtA []byte) (int, error) {
-	var i int
-	_ = i
-	var l int
-	_ = l
-	if len(m.Content) > 0 {
-		dAtA[i] = 0xa
-		i++
-		i = encodeVarintGenerated(dAtA, i, uint64(len(m.Content)))
-		i += copy(dAtA[i:], m.Content)
-	}
-	return i, nil
-}
-
-func (m *ParseASTResponse) Marshal() (dAtA []byte, err error) {
-	size := m.ProtoSize()
-	dAtA = make([]byte, size)
-	n, err := m.MarshalTo(dAtA)
-	if err != nil {
-		return nil, err
-	}
-	return dAtA[:n], nil
-}
-
-func (m *ParseASTResponse) MarshalTo(dAtA []byte) (int, error) {
-	var i int
-	_ = i
-	var l int
-	_ = l
-	if m.Status != 0 {
-		dAtA[i] = 0x8
-		i++
-		i = encodeVarintGenerated(dAtA, i, uint64(m.Status))
-	}
-	if len(m.Errors) > 0 {
-		for _, s := range m.Errors {
-			dAtA[i] = 0x12
-			i++
-			l = len(s)
-			for l >= 1<<7 {
-				dAtA[i] = uint8(uint64(l)&0x7f | 0x80)
-				l >>= 7
-				i++
-			}
-			dAtA[i] = uint8(l)
-			i++
-			i += copy(dAtA[i:], s)
-		}
-	}
-	if m.AST != nil {
-		dAtA[i] = 0x1a
-		i++
-		i = encodeVarintGenerated(dAtA, i, uint64(m.AST.ProtoSize()))
-		n1, err := m.AST.MarshalTo(dAtA[i:])
-		if err != nil {
-			return 0, err
-		}
-		i += n1
-	}
-	return i, nil
 }
 
 func (m *ParseUASTRequest) Marshal() (dAtA []byte, err error) {
@@ -326,11 +205,11 @@ func (m *ParseUASTResponse) MarshalTo(dAtA []byte) (int, error) {
 		dAtA[i] = 0x1a
 		i++
 		i = encodeVarintGenerated(dAtA, i, uint64(m.UAST.ProtoSize()))
-		n2, err := m.UAST.MarshalTo(dAtA[i:])
+		n1, err := m.UAST.MarshalTo(dAtA[i:])
 		if err != nil {
 			return 0, err
 		}
-		i += n2
+		i += n1
 	}
 	return i, nil
 }
@@ -362,35 +241,6 @@ func encodeVarintGenerated(dAtA []byte, offset int, v uint64) int {
 	dAtA[offset] = uint8(v)
 	return offset + 1
 }
-func (m *ParseASTRequest) ProtoSize() (n int) {
-	var l int
-	_ = l
-	l = len(m.Content)
-	if l > 0 {
-		n += 1 + l + sovGenerated(uint64(l))
-	}
-	return n
-}
-
-func (m *ParseASTResponse) ProtoSize() (n int) {
-	var l int
-	_ = l
-	if m.Status != 0 {
-		n += 1 + sovGenerated(uint64(m.Status))
-	}
-	if len(m.Errors) > 0 {
-		for _, s := range m.Errors {
-			l = len(s)
-			n += 1 + l + sovGenerated(uint64(l))
-		}
-	}
-	if m.AST != nil {
-		l = m.AST.ProtoSize()
-		n += 1 + l + sovGenerated(uint64(l))
-	}
-	return n
-}
-
 func (m *ParseUASTRequest) ProtoSize() (n int) {
 	var l int
 	_ = l
@@ -432,216 +282,6 @@ func sovGenerated(x uint64) (n int) {
 }
 func sozGenerated(x uint64) (n int) {
 	return sovGenerated(uint64((x << 1) ^ uint64((int64(x) >> 63))))
-}
-func (m *ParseASTRequest) Unmarshal(dAtA []byte) error {
-	l := len(dAtA)
-	iNdEx := 0
-	for iNdEx < l {
-		preIndex := iNdEx
-		var wire uint64
-		for shift := uint(0); ; shift += 7 {
-			if shift >= 64 {
-				return ErrIntOverflowGenerated
-			}
-			if iNdEx >= l {
-				return io.ErrUnexpectedEOF
-			}
-			b := dAtA[iNdEx]
-			iNdEx++
-			wire |= (uint64(b) & 0x7F) << shift
-			if b < 0x80 {
-				break
-			}
-		}
-		fieldNum := int32(wire >> 3)
-		wireType := int(wire & 0x7)
-		if wireType == 4 {
-			return fmt.Errorf("proto: ParseASTRequest: wiretype end group for non-group")
-		}
-		if fieldNum <= 0 {
-			return fmt.Errorf("proto: ParseASTRequest: illegal tag %d (wire type %d)", fieldNum, wire)
-		}
-		switch fieldNum {
-		case 1:
-			if wireType != 2 {
-				return fmt.Errorf("proto: wrong wireType = %d for field Content", wireType)
-			}
-			var stringLen uint64
-			for shift := uint(0); ; shift += 7 {
-				if shift >= 64 {
-					return ErrIntOverflowGenerated
-				}
-				if iNdEx >= l {
-					return io.ErrUnexpectedEOF
-				}
-				b := dAtA[iNdEx]
-				iNdEx++
-				stringLen |= (uint64(b) & 0x7F) << shift
-				if b < 0x80 {
-					break
-				}
-			}
-			intStringLen := int(stringLen)
-			if intStringLen < 0 {
-				return ErrInvalidLengthGenerated
-			}
-			postIndex := iNdEx + intStringLen
-			if postIndex > l {
-				return io.ErrUnexpectedEOF
-			}
-			m.Content = string(dAtA[iNdEx:postIndex])
-			iNdEx = postIndex
-		default:
-			iNdEx = preIndex
-			skippy, err := skipGenerated(dAtA[iNdEx:])
-			if err != nil {
-				return err
-			}
-			if skippy < 0 {
-				return ErrInvalidLengthGenerated
-			}
-			if (iNdEx + skippy) > l {
-				return io.ErrUnexpectedEOF
-			}
-			iNdEx += skippy
-		}
-	}
-
-	if iNdEx > l {
-		return io.ErrUnexpectedEOF
-	}
-	return nil
-}
-func (m *ParseASTResponse) Unmarshal(dAtA []byte) error {
-	l := len(dAtA)
-	iNdEx := 0
-	for iNdEx < l {
-		preIndex := iNdEx
-		var wire uint64
-		for shift := uint(0); ; shift += 7 {
-			if shift >= 64 {
-				return ErrIntOverflowGenerated
-			}
-			if iNdEx >= l {
-				return io.ErrUnexpectedEOF
-			}
-			b := dAtA[iNdEx]
-			iNdEx++
-			wire |= (uint64(b) & 0x7F) << shift
-			if b < 0x80 {
-				break
-			}
-		}
-		fieldNum := int32(wire >> 3)
-		wireType := int(wire & 0x7)
-		if wireType == 4 {
-			return fmt.Errorf("proto: ParseASTResponse: wiretype end group for non-group")
-		}
-		if fieldNum <= 0 {
-			return fmt.Errorf("proto: ParseASTResponse: illegal tag %d (wire type %d)", fieldNum, wire)
-		}
-		switch fieldNum {
-		case 1:
-			if wireType != 0 {
-				return fmt.Errorf("proto: wrong wireType = %d for field Status", wireType)
-			}
-			m.Status = 0
-			for shift := uint(0); ; shift += 7 {
-				if shift >= 64 {
-					return ErrIntOverflowGenerated
-				}
-				if iNdEx >= l {
-					return io.ErrUnexpectedEOF
-				}
-				b := dAtA[iNdEx]
-				iNdEx++
-				m.Status |= (Status(b) & 0x7F) << shift
-				if b < 0x80 {
-					break
-				}
-			}
-		case 2:
-			if wireType != 2 {
-				return fmt.Errorf("proto: wrong wireType = %d for field Errors", wireType)
-			}
-			var stringLen uint64
-			for shift := uint(0); ; shift += 7 {
-				if shift >= 64 {
-					return ErrIntOverflowGenerated
-				}
-				if iNdEx >= l {
-					return io.ErrUnexpectedEOF
-				}
-				b := dAtA[iNdEx]
-				iNdEx++
-				stringLen |= (uint64(b) & 0x7F) << shift
-				if b < 0x80 {
-					break
-				}
-			}
-			intStringLen := int(stringLen)
-			if intStringLen < 0 {
-				return ErrInvalidLengthGenerated
-			}
-			postIndex := iNdEx + intStringLen
-			if postIndex > l {
-				return io.ErrUnexpectedEOF
-			}
-			m.Errors = append(m.Errors, string(dAtA[iNdEx:postIndex]))
-			iNdEx = postIndex
-		case 3:
-			if wireType != 2 {
-				return fmt.Errorf("proto: wrong wireType = %d for field AST", wireType)
-			}
-			var msglen int
-			for shift := uint(0); ; shift += 7 {
-				if shift >= 64 {
-					return ErrIntOverflowGenerated
-				}
-				if iNdEx >= l {
-					return io.ErrUnexpectedEOF
-				}
-				b := dAtA[iNdEx]
-				iNdEx++
-				msglen |= (int(b) & 0x7F) << shift
-				if b < 0x80 {
-					break
-				}
-			}
-			if msglen < 0 {
-				return ErrInvalidLengthGenerated
-			}
-			postIndex := iNdEx + msglen
-			if postIndex > l {
-				return io.ErrUnexpectedEOF
-			}
-			if m.AST == nil {
-				m.AST = &github_com_bblfsh_sdk_uast.Node{}
-			}
-			if err := m.AST.Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
-				return err
-			}
-			iNdEx = postIndex
-		default:
-			iNdEx = preIndex
-			skippy, err := skipGenerated(dAtA[iNdEx:])
-			if err != nil {
-				return err
-			}
-			if skippy < 0 {
-				return ErrInvalidLengthGenerated
-			}
-			if (iNdEx + skippy) > l {
-				return io.ErrUnexpectedEOF
-			}
-			iNdEx += skippy
-		}
-	}
-
-	if iNdEx > l {
-		return io.ErrUnexpectedEOF
-	}
-	return nil
 }
 func (m *ParseUASTRequest) Unmarshal(dAtA []byte) error {
 	l := len(dAtA)
@@ -963,34 +603,30 @@ func init() {
 }
 
 var fileDescriptorGenerated = []byte{
-	// 451 bytes of a gzipped FileDescriptorProto
+	// 399 bytes of a gzipped FileDescriptorProto
 	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x09, 0x6e, 0x88, 0x02, 0xff, 0xe2, 0xd2, 0x4b, 0xcf, 0x2c, 0xc9,
 	0x28, 0x4d, 0xd2, 0x4b, 0xce, 0xcf, 0xd5, 0x4f, 0x4a, 0xca, 0x49, 0x2b, 0xce, 0xd0, 0x2f, 0x4e,
 	0xc9, 0xd6, 0x2f, 0x28, 0xca, 0x2f, 0xc9, 0x4f, 0xce, 0xcf, 0xd1, 0x4f, 0x4f, 0xcd, 0x4b, 0x2d,
 	0x4a, 0x2c, 0x49, 0x4d, 0xd1, 0x03, 0x0b, 0x09, 0xc9, 0x21, 0xd4, 0xeb, 0x41, 0xd4, 0xeb, 0x15,
 	0xa7, 0x64, 0xeb, 0xc1, 0xd4, 0x4b, 0xe9, 0x22, 0x99, 0x97, 0x9e, 0x9f, 0x9e, 0x0f, 0x31, 0x29,
 	0xa9, 0x34, 0x0d, 0xcc, 0x03, 0x73, 0xc0, 0x2c, 0x88, 0x0e, 0x29, 0x2d, 0xec, 0xd6, 0x97, 0x26,
-	0x16, 0x97, 0xa0, 0x5b, 0xad, 0x64, 0xca, 0xc5, 0x1f, 0x90, 0x58, 0x54, 0x9c, 0xea, 0x18, 0x1c,
-	0x12, 0x94, 0x5a, 0x58, 0x9a, 0x5a, 0x5c, 0x22, 0x24, 0xc1, 0xc5, 0x9e, 0x9c, 0x9f, 0x57, 0x92,
-	0x9a, 0x57, 0x22, 0xc1, 0xa8, 0xc0, 0xa8, 0xc1, 0x19, 0x04, 0xe3, 0x5a, 0x71, 0x74, 0x2c, 0x90,
-	0x67, 0xf8, 0xb0, 0x50, 0x9e, 0x41, 0x69, 0x23, 0x23, 0x97, 0x00, 0x42, 0x5f, 0x71, 0x41, 0x7e,
-	0x5e, 0x71, 0xaa, 0x90, 0x1d, 0x17, 0x5b, 0x71, 0x49, 0x62, 0x49, 0x69, 0x31, 0x58, 0x1f, 0x9f,
-	0x91, 0x9a, 0x1e, 0x7e, 0x7f, 0xe9, 0x05, 0x83, 0x55, 0x07, 0x41, 0x75, 0x09, 0x89, 0x71, 0xb1,
-	0xa5, 0x16, 0x15, 0xe5, 0x17, 0x15, 0x4b, 0x30, 0x29, 0x30, 0x6b, 0x70, 0x06, 0x41, 0x79, 0x42,
-	0xd6, 0x5c, 0xcc, 0x89, 0xc5, 0x25, 0x12, 0xcc, 0x0a, 0x8c, 0x1a, 0xdc, 0x46, 0x0a, 0x38, 0x0c,
-	0x05, 0xf9, 0x4e, 0xcf, 0x2f, 0x3f, 0x25, 0xd5, 0x89, 0xfd, 0xd1, 0x3d, 0x79, 0x66, 0x90, 0xbb,
-	0x40, 0xba, 0x90, 0xdc, 0x6c, 0x06, 0x75, 0x72, 0x28, 0x89, 0x7e, 0xdd, 0xca, 0xc8, 0x25, 0x88,
-	0xa4, 0x91, 0xc6, 0x9e, 0xb5, 0xe3, 0x62, 0x29, 0x25, 0xc5, 0xb7, 0x1c, 0x8f, 0xee, 0xc9, 0xb3,
-	0x80, 0x5d, 0x06, 0xd6, 0x87, 0x70, 0xb7, 0x56, 0x10, 0x17, 0x1b, 0xc4, 0x4e, 0x21, 0x3e, 0x2e,
-	0x26, 0x7f, 0x6f, 0x01, 0x06, 0x29, 0xb6, 0xae, 0xb9, 0x0a, 0x4c, 0xfe, 0xd9, 0x42, 0x22, 0x5c,
-	0xac, 0xae, 0x41, 0x41, 0xfe, 0x41, 0x02, 0x8c, 0x52, 0x9c, 0x5d, 0x73, 0x15, 0x58, 0x5d, 0x41,
-	0x56, 0x83, 0x44, 0xdd, 0x1c, 0x43, 0x1c, 0x7d, 0x04, 0x98, 0x20, 0xa2, 0x6e, 0x89, 0x25, 0x89,
-	0x39, 0x52, 0x3c, 0x1d, 0x8b, 0xe5, 0x18, 0x56, 0x2c, 0x91, 0x63, 0x38, 0xb0, 0x44, 0x8e, 0xc1,
-	0xe8, 0x13, 0x23, 0x17, 0x7f, 0x00, 0xd4, 0x47, 0xc1, 0xa9, 0x45, 0x65, 0x99, 0xc9, 0xa9, 0x42,
-	0xb9, 0x5c, 0x1c, 0xb0, 0xa4, 0x20, 0xa4, 0x4f, 0x28, 0x14, 0xd0, 0x12, 0x9b, 0x94, 0x01, 0xf1,
-	0x1a, 0xa0, 0x01, 0x5f, 0xc0, 0xc5, 0x09, 0x8f, 0x0d, 0x21, 0xe2, 0xb4, 0x23, 0xc5, 0xb8, 0x94,
-	0x21, 0x09, 0x3a, 0x20, 0x36, 0x3a, 0xc9, 0x9d, 0x78, 0x24, 0xc7, 0x78, 0xe1, 0x91, 0x1c, 0xe3,
-	0x83, 0x47, 0x72, 0x0c, 0x33, 0x1e, 0xcb, 0x31, 0x2c, 0x78, 0x2c, 0xc7, 0x18, 0xc5, 0x01, 0xd3,
-	0x91, 0xc4, 0x06, 0x66, 0x19, 0x03, 0x02, 0x00, 0x00, 0xff, 0xff, 0x2c, 0x96, 0xde, 0xd1, 0xf7,
-	0x03, 0x00, 0x00,
+	0x16, 0x97, 0xa0, 0x5b, 0xad, 0x64, 0xc6, 0x25, 0x10, 0x90, 0x58, 0x54, 0x9c, 0x1a, 0xea, 0x18,
+	0x1c, 0x12, 0x94, 0x5a, 0x58, 0x9a, 0x5a, 0x5c, 0x22, 0x24, 0xc1, 0xc5, 0x9e, 0x9c, 0x9f, 0x57,
+	0x92, 0x9a, 0x57, 0x22, 0xc1, 0xa8, 0xc0, 0xa8, 0xc1, 0x19, 0x04, 0xe3, 0x5a, 0x71, 0x74, 0x2c,
+	0x90, 0x67, 0xf8, 0xb0, 0x50, 0x9e, 0x41, 0x69, 0x2b, 0x23, 0x97, 0x20, 0x92, 0xc6, 0xe2, 0x82,
+	0xfc, 0xbc, 0xe2, 0x54, 0x21, 0x3b, 0x2e, 0xb6, 0xe2, 0x92, 0xc4, 0x92, 0xd2, 0x62, 0xb0, 0x46,
+	0x3e, 0x23, 0x35, 0x3d, 0xfc, 0x3e, 0xd3, 0x0b, 0x06, 0xab, 0x0e, 0x82, 0xea, 0x12, 0x12, 0xe3,
+	0x62, 0x4b, 0x2d, 0x2a, 0xca, 0x2f, 0x2a, 0x96, 0x60, 0x52, 0x60, 0xd6, 0xe0, 0x0c, 0x82, 0xf2,
+	0x84, 0xec, 0xb8, 0x58, 0x40, 0xae, 0x97, 0x60, 0x56, 0x60, 0xd4, 0xe0, 0x36, 0x52, 0xc0, 0x61,
+	0x2a, 0x48, 0x89, 0x9e, 0x5f, 0x7e, 0x4a, 0xaa, 0x13, 0xc7, 0xa3, 0x7b, 0xf2, 0x2c, 0x60, 0x97,
+	0x81, 0xf5, 0x21, 0xdc, 0xad, 0x15, 0xc4, 0xc5, 0x06, 0xb1, 0x53, 0x88, 0x8f, 0x8b, 0xc9, 0xdf,
+	0x5b, 0x80, 0x41, 0x8a, 0xad, 0x6b, 0xae, 0x02, 0x93, 0x7f, 0xb6, 0x90, 0x08, 0x17, 0xab, 0x6b,
+	0x50, 0x90, 0x7f, 0x90, 0x00, 0xa3, 0x14, 0x67, 0xd7, 0x5c, 0x05, 0x56, 0x57, 0x90, 0xd5, 0x20,
+	0x51, 0x37, 0xc7, 0x10, 0x47, 0x1f, 0x01, 0x26, 0x88, 0xa8, 0x5b, 0x62, 0x49, 0x62, 0x8e, 0x14,
+	0x4f, 0xc7, 0x62, 0x39, 0x86, 0x15, 0x4b, 0xe4, 0x18, 0x0e, 0x2c, 0x91, 0x63, 0x30, 0x6a, 0x66,
+	0xe4, 0xe2, 0x0f, 0x80, 0xfa, 0x28, 0x38, 0xb5, 0xa8, 0x2c, 0x33, 0x39, 0x55, 0xa8, 0x80, 0x8b,
+	0x13, 0x1e, 0x3c, 0x42, 0x06, 0x84, 0x82, 0x01, 0x3d, 0x0a, 0xa4, 0x0c, 0x49, 0xd0, 0x01, 0x09,
+	0x7b, 0x27, 0xb9, 0x13, 0x8f, 0xe4, 0x18, 0x2f, 0x3c, 0x92, 0x63, 0x7c, 0xf0, 0x48, 0x8e, 0x61,
+	0xc6, 0x63, 0x39, 0x86, 0x05, 0x8f, 0xe5, 0x18, 0xa3, 0x38, 0x60, 0x3a, 0x92, 0xd8, 0xc0, 0x2c,
+	0x63, 0x40, 0x00, 0x00, 0x00, 0xff, 0xff, 0x7a, 0xe1, 0x0b, 0x3c, 0x9d, 0x02, 0x00, 0x00,
 }

--- a/protocol/generated.proto
+++ b/protocol/generated.proto
@@ -8,22 +8,6 @@ option (gogoproto.protosizer_all) = true;
 option (gogoproto.sizer_all) = false;
 option go_package = "protocol";
 
-// ParseASTRequest is a request to parse a file and get its AST.
-message ParseASTRequest {
-	option (gogoproto.goproto_getters) = false;
-	option (gogoproto.typedecl) = false;
-	string content = 1;
-}
-
-// ParseASTResponse is the reply to ParseASTRequest.
-message ParseASTResponse {
-	option (gogoproto.goproto_getters) = false;
-	option (gogoproto.typedecl) = false;
-	github.com.bblfsh.sdk.protocol.Status status = 1;
-	repeated string errors = 2;
-	github.com.bblfsh.sdk.uast.Node ast = 3 [(gogoproto.customname) = "AST"];
-}
-
 // ParseUASTRequest is a request to parse a file and get its UAST.
 message ParseUASTRequest {
 	option (gogoproto.goproto_getters) = false;
@@ -54,8 +38,6 @@ enum Status {
 }
 
 service ProtocolService {
-	// ParseAST uses DefaultParser to process the given AST parsing request.
-	rpc ParseAST (github.com.bblfsh.sdk.protocol.ParseASTRequest) returns (github.com.bblfsh.sdk.protocol.ParseASTResponse);
 	// ParseUAST uses DefaultParser to process the given UAST parsing request.
 	rpc ParseUAST (github.com.bblfsh.sdk.protocol.ParseUASTRequest) returns (github.com.bblfsh.sdk.protocol.ParseUASTResponse);
 }

--- a/protocol/internal/testdriver/main.go
+++ b/protocol/internal/testdriver/main.go
@@ -11,10 +11,10 @@ var build string
 
 func main() {
 	d := driver.Driver{
-		Version:          version,
-		Build:            build,
-		ASTParserBuilder: normalizer.ASTParserBuilder,
-		Annotate:         normalizer.AnnotationRules,
+		Version:           version,
+		Build:             build,
+		UASTParserBuilder: normalizer.UASTParserBuilder,
+		Annotate:          normalizer.AnnotationRules,
 	}
 	d.Exec()
 }

--- a/protocol/internal/testnative/main.go
+++ b/protocol/internal/testnative/main.go
@@ -18,7 +18,7 @@ func main() {
 	dec := jsonlines.NewDecoder(os.Stdin)
 	enc := jsonlines.NewEncoder(os.Stdout)
 	for {
-		req := &protocol.ParseASTRequest{}
+		req := &protocol.ParseUASTRequest{}
 		if err := dec.Decode(req); err != nil {
 			if err == io.EOF {
 				os.Exit(0)

--- a/protocol/native/native.go
+++ b/protocol/native/native.go
@@ -35,13 +35,13 @@ func ExecParser(toNoder ToNoder, path string, args ...string) (*Parser, error) {
 	return &Parser{Client: c, ToNoder: toNoder}, nil
 }
 
-func (p *Parser) ParseAST(req *protocol.ParseASTRequest) (*protocol.ParseASTResponse, error) {
+func (p *Parser) ParseUAST(req *protocol.ParseUASTRequest) (*protocol.ParseUASTResponse, error) {
 	nativeResp, err := p.Client.ParseNativeAST(&ParseASTRequest{Content: req.Content})
 	if err != nil {
 		return nil, err
 	}
 
-	resp := &protocol.ParseASTResponse{
+	resp := &protocol.ParseUASTResponse{
 		Status: nativeResp.Status,
 		Errors: nativeResp.Errors,
 	}
@@ -56,7 +56,7 @@ func (p *Parser) ParseAST(req *protocol.ParseASTRequest) (*protocol.ParseASTResp
 		return resp, nil
 	}
 
-	resp.AST = ast
+	resp.UAST = ast
 	return resp, nil
 }
 

--- a/protocol/protocol.go
+++ b/protocol/protocol.go
@@ -71,47 +71,13 @@ type ParseUASTResponse struct {
 	UAST *uast.Node `json:"uast"`
 }
 
-// ParseASTRequest is a request to parse a file and get its AST.
-//proteus:generate
-type ParseASTRequest struct {
-	// Content is the source code to be parsed.
-	Content string `json:"content"`
-}
-
-// ParseASTResponse is the reply to ParseASTRequest.
-//proteus:generate
-type ParseASTResponse struct {
-	// Status is the status of the parsing request.
-	Status Status `json:"status"`
-	// Errors contrains a list of parsing errors. If Status is ok, this list
-	// should always be empty.
-	Errors []string `json:"errors"`
-	// AST contains the parsed AST in its normalized form. That is the same
-	// type as the UAST, but without any annotation.
-	AST *uast.Node `json:"ast"`
-}
-
-// Parser can parse AST and UAST.
+// Parser can parse UAST.
 type Parser interface {
-	ParseAST(*ParseASTRequest) *ParseASTResponse
 	ParseUAST(*ParseUASTRequest) *ParseUASTResponse
 }
 
 // DefaultParser is the default parser used by ParseAST and ParseUAST.
 var DefaultParser Parser
-
-// ParseAST uses DefaultParser to process the given AST parsing request.
-//proteus:generate
-func ParseAST(req *ParseASTRequest) *ParseASTResponse {
-	if DefaultParser == nil {
-		return &ParseASTResponse{
-			Status: Fatal,
-			Errors: []string{"no default parser registered"},
-		}
-	}
-
-	return DefaultParser.ParseAST(req)
-}
 
 // ParseUAST uses DefaultParser to process the given UAST parsing request.
 //proteus:generate

--- a/protocol/protocol_test.go
+++ b/protocol/protocol_test.go
@@ -15,10 +15,6 @@ import (
 
 type mockParser struct{}
 
-func (p *mockParser) ParseAST(req *protocol.ParseASTRequest) *protocol.ParseASTResponse {
-	return &protocol.ParseASTResponse{Status: protocol.Ok}
-}
-
 func (p *mockParser) ParseUAST(req *protocol.ParseUASTRequest) *protocol.ParseUASTResponse {
 	return &protocol.ParseUASTResponse{Status: protocol.Ok}
 }
@@ -54,13 +50,6 @@ func TestInvalidParser(t *testing.T) {
 	require.NoError(err)
 	require.Equal(protocol.Fatal, uresp.Status)
 
-	areq := &protocol.ParseASTRequest{
-		Content: "my source code",
-	}
-	aresp, err := client.ParseAST(context.TODO(), areq)
-	require.NoError(err)
-	require.Equal(protocol.Fatal, aresp.Status)
-
 	server.GracefulStop()
 }
 
@@ -84,23 +73,15 @@ func Example() {
 
 	client := protocol.NewProtocolServiceClient(conn)
 
-	ureq := &protocol.ParseUASTRequest{Content: "my source code"}
-	fmt.Println("Sending ParseUAST for:", ureq.Content)
-	uresp, err := client.ParseUAST(context.TODO(), ureq)
+	req := &protocol.ParseUASTRequest{Content: "my source code"}
+	fmt.Println("Sending ParseUAST for:", req.Content)
+	resp, err := client.ParseUAST(context.TODO(), req)
 	checkError(err)
-	fmt.Println("Got response with status:", uresp.Status.String())
-
-	areq := &protocol.ParseASTRequest{Content: "my source code"}
-	fmt.Println("Sending ParseAST for:", areq.Content)
-	aresp, err := client.ParseAST(context.TODO(), areq)
-	checkError(err)
-	fmt.Println("Got response with status:", aresp.Status.String())
+	fmt.Println("Got response with status:", resp.Status.String())
 
 	server.GracefulStop()
 
 	//Output: Sending ParseUAST for: my source code
-	// Got response with status: ok
-	// Sending ParseAST for: my source code
 	// Got response with status: ok
 }
 

--- a/protocol/server.proteus.go
+++ b/protocol/server.proteus.go
@@ -10,11 +10,6 @@ type protocolServiceServer struct {
 func NewProtocolServiceServer() *protocolServiceServer {
 	return &protocolServiceServer{}
 }
-func (s *protocolServiceServer) ParseAST(ctx context.Context, in *ParseASTRequest) (result *ParseASTResponse, err error) {
-	result = new(ParseASTResponse)
-	result = ParseAST(in)
-	return
-}
 func (s *protocolServiceServer) ParseUAST(ctx context.Context, in *ParseUASTRequest) (result *ParseUASTResponse, err error) {
 	result = new(ParseUASTResponse)
 	result = ParseUAST(in)


### PR DESCRIPTION
Now driver.UASTParser conforms to protocol.Parser. That is,
it does not use a second return value for error and uses the
error handling of ParseUASTRequest.
