### PR TITLE
Autogenerate conversion tables for UAST

### DIFF
--- a/assets/build/bindata.go
+++ b/assets/build/bindata.go
@@ -493,6 +493,7 @@ BUILD_IMAGE=$(DOCKER_BUILD_NATIVE_IMAGE) $(DOCKER_BUILD_DRIVER_IMAGE) $(DOCKER_I
 
 # golang runtime commands
 GO_CMD = go
+GO_RUN = $(GO_CMD) run
 GO_TEST = $(GO_CMD) test -v
 GO_LDFLAGS = -X main.version=$(DRIVER_VERSION) -X main.build=$(BUILD_ID)
 
@@ -526,6 +527,10 @@ ALLOWED_IN_DOCKERFILE = \
 	BUILD_USER BUILD_UID BUILD_PATH \
 	DOCKER_IMAGE DOCKER_IMAGE_VERSIONED DOCKER_BUILD_NATIVE_IMAGE
 
+# generated documentation
+DOCGEN_FILES += \
+	ANNOTATION.md
+
 # we export the variable to allow envsubst, substitute the vars in the
 # Dockerfiles
 export
@@ -557,7 +562,7 @@ test-driver-internal: build-native-internal
 	@cd driver; \
 	$(RUN_VERBOSE) $(GO_TEST) ./...
 
-build: | build-native build-driver $(DOCKER_IMAGE_VERSIONED)
+build: docgen | build-native build-driver $(DOCKER_IMAGE_VERSIONED)
 build-native: $(BUILD_PATH) $(DOCKER_BUILD_NATIVE_IMAGE)
 	@$(RUN) $(BUILD_NATIVE_CMD) make build-native-internal
 
@@ -583,6 +588,11 @@ push: build
 	@$(RUN) $(DOCKER_PUSH) $(call unescape_docker_tag,$(DOCKER_IMAGE_VERSIONED))
 	@$(RUN) $(DOCKER_PUSH) $(call unescape_docker_tag,$(DOCKER_IMAGE):latest)
 
+docgen: $(DOCGEN_FILES)
+
+ANNOTATION.md: driver/normalizer/annotation.go
+	@$(GO_RUN) driver/main.go docgen > $@
+
 validate:
 	@$(RUN) $(bblfsh-sdk) update --dry-run
 
@@ -600,7 +610,7 @@ func makeRulesMk() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "make/rules.mk", size: 3858, mode: os.FileMode(420), modTime: time.Unix(1, 0)}
+	info := bindataFileInfo{name: "make/rules.mk", size: 4060, mode: os.FileMode(420), modTime: time.Unix(1, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }

--- a/etc/build/make/rules.mk
+++ b/etc/build/make/rules.mk
@@ -24,6 +24,7 @@ BUILD_IMAGE=$(DOCKER_BUILD_NATIVE_IMAGE) $(DOCKER_BUILD_DRIVER_IMAGE) $(DOCKER_I
 
 # golang runtime commands
 GO_CMD = go
+GO_RUN = $(GO_CMD) run
 GO_TEST = $(GO_CMD) test -v
 GO_LDFLAGS = -X main.version=$(DRIVER_VERSION) -X main.build=$(BUILD_ID)
 
@@ -57,6 +58,10 @@ ALLOWED_IN_DOCKERFILE = \
 	BUILD_USER BUILD_UID BUILD_PATH \
 	DOCKER_IMAGE DOCKER_IMAGE_VERSIONED DOCKER_BUILD_NATIVE_IMAGE
 
+# generated documentation
+DOCGEN_FILES += \
+	ANNOTATION.md
+
 # we export the variable to allow envsubst, substitute the vars in the
 # Dockerfiles
 export
@@ -88,7 +93,7 @@ test-driver-internal: build-native-internal
 	@cd driver; \
 	$(RUN_VERBOSE) $(GO_TEST) ./...
 
-build: | build-native build-driver $(DOCKER_IMAGE_VERSIONED)
+build: docgen | build-native build-driver $(DOCKER_IMAGE_VERSIONED)
 build-native: $(BUILD_PATH) $(DOCKER_BUILD_NATIVE_IMAGE)
 	@$(RUN) $(BUILD_NATIVE_CMD) make build-native-internal
 
@@ -113,6 +118,11 @@ push: build
 		$(call unescape_docker_tag,$(DOCKER_IMAGE)):latest
 	@$(RUN) $(DOCKER_PUSH) $(call unescape_docker_tag,$(DOCKER_IMAGE_VERSIONED))
 	@$(RUN) $(DOCKER_PUSH) $(call unescape_docker_tag,$(DOCKER_IMAGE):latest)
+
+docgen: $(DOCGEN_FILES)
+
+ANNOTATION.md: driver/normalizer/annotation.go
+	@$(GO_RUN) driver/main.go docgen > $@
 
 validate:
 	@$(RUN) $(bblfsh-sdk) update --dry-run

--- a/protocol/driver/driver.go
+++ b/protocol/driver/driver.go
@@ -58,6 +58,7 @@ func (d *Driver) Run(args []string) error {
 	parser.AddCommand("parse-native", "", "", &parseNativeASTCommand{cmd: cmd})
 	parser.AddCommand("parse-uast", "", "", &parseUASTCommand{cmd: cmd})
 	parser.AddCommand("tokenize", "", "", &tokenizeCommand{cmd: cmd})
+	parser.AddCommand("docgen", "", "", &docGenCommand{cmd: cmd})
 
 	if _, err := parser.ParseArgs(args[1:]); err != nil {
 		if err, ok := err.(*flags.Error); ok {
@@ -277,4 +278,13 @@ func (c *tokenizeCommand) Execute(args []string) error {
 	toks := uast.Tokens(resp.UAST)
 	_, err = fmt.Fprintf(c.Out, strings.Join(toks, "\t"))
 	return err
+}
+
+type docGenCommand struct {
+	cmd
+}
+
+func (c *docGenCommand) Execute(args []string) error {
+	fmt.Print(c.Driver.Annotate)
+	return nil
 }

--- a/protocol/driver/driver_test.go
+++ b/protocol/driver/driver_test.go
@@ -80,6 +80,7 @@ Help Options:
   -h, --help  Show this help message
 
 Available commands:
+  docgen
   parse-native
   parse-uast
   serve

--- a/uast/ann/ann_test.go
+++ b/uast/ann/ann_test.go
@@ -20,11 +20,11 @@ func TestHasInternalType(t *testing.T) {
 	}
 
 	pred := HasInternalType("foo")
-	require.True(pred(node("foo")))
-	require.False(pred(nil))
-	require.False(pred(&Node{}))
-	require.False(pred(node("")))
-	require.False(pred(node("bar")))
+	require.True(pred.Eval(node("foo")))
+	require.False(pred.Eval(nil))
+	require.False(pred.Eval(&Node{}))
+	require.False(pred.Eval(node("")))
+	require.False(pred.Eval(node("bar")))
 }
 
 func TestHasInternalRole(t *testing.T) {
@@ -37,11 +37,11 @@ func TestHasInternalRole(t *testing.T) {
 	}
 
 	pred := HasInternalRole("foo")
-	require.True(pred(node("foo")))
-	require.False(pred(nil))
-	require.False(pred(&Node{}))
-	require.False(pred(node("")))
-	require.False(pred(node("bar")))
+	require.True(pred.Eval(node("foo")))
+	require.False(pred.Eval(nil))
+	require.False(pred.Eval(&Node{}))
+	require.False(pred.Eval(node("")))
+	require.False(pred.Eval(node("bar")))
 }
 
 func TestHasProperty(t *testing.T) {
@@ -54,12 +54,12 @@ func TestHasProperty(t *testing.T) {
 	}
 
 	pred := HasProperty("myprop", "foo")
-	require.True(pred(node("myprop", "foo")))
-	require.False(pred(nil))
-	require.False(pred(&Node{}))
-	require.False(pred(node("myprop", "bar")))
-	require.False(pred(node("otherprop", "foo")))
-	require.False(pred(node("otherprop", "bar")))
+	require.True(pred.Eval(node("myprop", "foo")))
+	require.False(pred.Eval(nil))
+	require.False(pred.Eval(&Node{}))
+	require.False(pred.Eval(node("myprop", "bar")))
+	require.False(pred.Eval(node("otherprop", "foo")))
+	require.False(pred.Eval(node("otherprop", "bar")))
 }
 
 func TestHasToken(t *testing.T) {
@@ -72,28 +72,28 @@ func TestHasToken(t *testing.T) {
 	}
 
 	pred := HasToken("foo")
-	require.True(pred(node("foo")))
-	require.False(pred(nil))
-	require.False(pred(&Node{}))
-	require.False(pred(node("")))
-	require.False(pred(node("bar")))
+	require.True(pred.Eval(node("foo")))
+	require.False(pred.Eval(nil))
+	require.False(pred.Eval(&Node{}))
+	require.False(pred.Eval(node("")))
+	require.False(pred.Eval(node("bar")))
 
 	pred = HasToken("")
-	require.True(pred(&Node{}))
-	require.True(pred(node("")))
-	require.False(pred(nil))
-	require.False(pred(node("bar")))
+	require.True(pred.Eval(&Node{}))
+	require.True(pred.Eval(node("")))
+	require.False(pred.Eval(nil))
+	require.False(pred.Eval(node("bar")))
 }
 
 func TestAny(t *testing.T) {
 	require := require.New(t)
 
 	pred := Any
-	require.True(pred(nil))
-	require.True(pred(&Node{}))
-	require.True(pred(NewNode()))
-	require.True(pred(&Node{InternalType: "foo"}))
-	require.True(pred(&Node{Token: "foo"}))
+	require.True(pred.Eval(nil))
+	require.True(pred.Eval(&Node{}))
+	require.True(pred.Eval(NewNode()))
+	require.True(pred.Eval(&Node{InternalType: "foo"}))
+	require.True(pred.Eval(&Node{Token: "foo"}))
 }
 
 func TestNot(t *testing.T) {
@@ -106,11 +106,11 @@ func TestNot(t *testing.T) {
 	}
 
 	pred := Not(HasInternalType("foo"))
-	require.False(pred(node("foo")))
-	require.True(pred(nil))
-	require.True(pred(&Node{}))
-	require.True(pred(node("")))
-	require.True(pred(node("bar")))
+	require.False(pred.Eval(node("foo")))
+	require.True(pred.Eval(nil))
+	require.True(pred.Eval(&Node{}))
+	require.True(pred.Eval(node("")))
+	require.True(pred.Eval(node("bar")))
 }
 
 func TestOr(t *testing.T) {
@@ -123,12 +123,12 @@ func TestOr(t *testing.T) {
 	}
 
 	pred := Or(HasInternalType("foo"), HasInternalType("bar"))
-	require.True(pred(node("foo")))
-	require.False(pred(nil))
-	require.False(pred(&Node{}))
-	require.False(pred(node("")))
-	require.True(pred(node("bar")))
-	require.False(pred(node("baz")))
+	require.True(pred.Eval(node("foo")))
+	require.False(pred.Eval(nil))
+	require.False(pred.Eval(&Node{}))
+	require.False(pred.Eval(node("")))
+	require.True(pred.Eval(node("bar")))
+	require.False(pred.Eval(node("baz")))
 }
 
 func TestAnd(t *testing.T) {
@@ -142,14 +142,14 @@ func TestAnd(t *testing.T) {
 	}
 
 	pred := And(HasInternalType("foo"), HasToken("bar"))
-	require.False(pred(node("foo", "")))
-	require.False(pred(nil))
-	require.False(pred(&Node{}))
-	require.False(pred(node("", "")))
-	require.False(pred(node("bar", "")))
-	require.False(pred(node("foo", "foo")))
-	require.False(pred(node("bar", "bar")))
-	require.True(pred(node("foo", "bar")))
+	require.False(pred.Eval(node("foo", "")))
+	require.False(pred.Eval(nil))
+	require.False(pred.Eval(&Node{}))
+	require.False(pred.Eval(node("", "")))
+	require.False(pred.Eval(node("bar", "")))
+	require.False(pred.Eval(node("foo", "foo")))
+	require.False(pred.Eval(node("bar", "bar")))
+	require.True(pred.Eval(node("foo", "bar")))
 }
 
 func TestHasChild(t *testing.T) {
@@ -172,13 +172,13 @@ func TestHasChild(t *testing.T) {
 		return n
 	}
 
-	require.False(pred(path("foo")))
-	require.False(pred(path("foo", "bar")))
-	require.False(pred(path("", "")))
-	require.False(pred(nil))
-	require.False(pred(&Node{}))
-	require.True(pred(path("bar", "foo")))
-	require.False(pred(path("bar", "baz", "foo")))
+	require.False(pred.Eval(path("foo")))
+	require.False(pred.Eval(path("foo", "bar")))
+	require.False(pred.Eval(path("", "")))
+	require.False(pred.Eval(nil))
+	require.False(pred.Eval(&Node{}))
+	require.True(pred.Eval(path("bar", "foo")))
+	require.False(pred.Eval(path("bar", "baz", "foo")))
 }
 
 func TestAddRoles(t *testing.T) {
@@ -188,7 +188,7 @@ func TestAddRoles(t *testing.T) {
 	input := NewNode()
 	expected := NewNode()
 	expected.Roles = []Role{Statement, Expression}
-	err := a(input)
+	err := a.Do(input)
 	require.NoError(err)
 	require.Equal(expected, input)
 }

--- a/uast/ann/xpathdescription.go
+++ b/uast/ann/xpathdescription.go
@@ -54,7 +54,8 @@ func (f *xPathDescription) fold(r *Rule) {
 
 	if len(r.actions) != 0 {
 		s := fmt.Sprintf("| %s | %s |",
-			f.current.String(), joinActions(r.actions, ", "))
+			markdownEscape(f.current.String()),
+			markdownEscape(joinActions(r.actions, ", ")))
 		f.descriptions = append(f.descriptions, abbreviate(s))
 	}
 
@@ -76,14 +77,43 @@ func joinActions(as []Action, sep string) string {
 // Idempotent.
 func abbreviate(s string) string {
 	// Replace the On(Any).Something at the begining with root
-	if !strings.HasPrefix(s, "| /self::*[*] | ") {
-		s = strings.Replace(s, "/self::*[*]", "", 1)
+	if !strings.HasPrefix(s, `| /self::\*\[\*\] | `) {
+		s = strings.Replace(s, `/self::\*\[\*\]`, "", 1)
 	}
 	// replace descendant:: with //
-	s = strings.Replace(s, "/descendant::*", "//*", -1) // no limit
+	s = strings.Replace(s, `/descendant::\*`, `//\*`, -1) // no limit
 	// replace child:: with /
 	s = strings.Replace(s, "/child::", "/", -1) // no limit
 	return s
+}
+
+func markdownEscape(s string) string {
+	var buf bytes.Buffer
+	for _, r := range s {
+		if mustEscape(r) {
+			buf.WriteRune('\\')
+		}
+		buf.WriteRune(r)
+	}
+	return buf.String()
+}
+
+func mustEscape(r rune) bool {
+	return r == '\\' ||
+		r == '|' ||
+		r == '*' ||
+		r == '_' ||
+		r == '{' ||
+		r == '}' ||
+		r == '[' ||
+		r == ']' ||
+		r == '(' ||
+		r == ')' ||
+		r == '#' ||
+		r == '+' ||
+		r == '-' ||
+		r == '.' ||
+		r == '!'
 }
 
 // Returns a string with all the description separated by a newline.

--- a/uast/ann/xpathdescription.go
+++ b/uast/ann/xpathdescription.go
@@ -1,0 +1,96 @@
+package ann
+
+import (
+	"bytes"
+	"fmt"
+	"strings"
+)
+
+// xPathDescription is a folder (as in "analyzer of recursive data
+// structures combining the information in its nodes", not as in
+// "directory").  It traverses Rules in pre-order, generating the
+// XPath-like description of each rule and a human readable description
+// of their associated actions.
+type xPathDescription struct {
+	current      path
+	descriptions []string
+}
+
+// A path represents how to get from the root of a rule to one of its
+// nodes.  We push nodes as we go deeper into the tree and pop them back
+// when we climb towards its root.
+type path []*Rule
+
+func (p *path) push(rule *Rule) {
+	*p = append(*p, rule)
+}
+
+func (p *path) pop() {
+	(*p)[len(*p)-1] = nil
+	*p = (*p)[:len(*p)-1]
+}
+
+// Returns the path in a format similar to XPath.
+func (p *path) String() string {
+	var buf bytes.Buffer
+	for _, r := range *p {
+		buf.WriteRune('/')
+		fmt.Fprintf(&buf, "%s::*", r.axis)
+		for _, p := range r.predicates {
+			fmt.Fprintf(&buf, "[%s]", p)
+		}
+	}
+	return buf.String()
+}
+
+// Calculates the description for all the nodes in the rule.
+func (f *xPathDescription) fold(r *Rule) {
+	if len(r.actions) == 0 && len(r.rules) == 0 {
+		return
+	}
+
+	(&f.current).push(r)
+	defer f.current.pop()
+
+	if len(r.actions) != 0 {
+		s := fmt.Sprintf("| %s | %s |",
+			f.current.String(), joinActions(r.actions, ", "))
+		f.descriptions = append(f.descriptions, abbreviate(s))
+	}
+
+	for _, child := range r.rules {
+		f.fold(child)
+	}
+}
+
+func joinActions(as []Action, sep string) string {
+	var buf bytes.Buffer
+	_sep := ""
+	for _, e := range as {
+		fmt.Fprintf(&buf, "%s%s", _sep, e)
+		_sep = sep
+	}
+	return buf.String()
+}
+
+// Idempotent.
+func abbreviate(s string) string {
+	// Replace the On(Any).Something at the begining with root
+	if !strings.HasPrefix(s, "| /self::*[*] | ") {
+		s = strings.Replace(s, "/self::*[*]", "", 1)
+	}
+	// replace descendant:: with //
+	s = strings.Replace(s, "/descendant::*", "//*", -1) // no limit
+	// replace child:: with /
+	s = strings.Replace(s, "/child::", "/", -1) // no limit
+	return s
+}
+
+// Returns a string with all the description separated by a newline.
+func (f *xPathDescription) String() string {
+	var buf bytes.Buffer
+	for _, e := range f.descriptions {
+		fmt.Fprintf(&buf, "%s\n", e)
+	}
+	return buf.String()
+}

--- a/uast/ann/xpathdescription_test.go
+++ b/uast/ann/xpathdescription_test.go
@@ -21,49 +21,49 @@ func TestRulesDocSuite(t *testing.T) {
 
 func (suite *RulesDocSuite) TestAny() {
 	rule := On(Any).Roles(uast.SimpleIdentifier)
-	expected := head + "| /self::*[*] | SimpleIdentifier |\n"
+	expected := head + `| /self::\*\[\*\] | SimpleIdentifier |` + "\n"
 	obtained := rule.String()
 	require.Equal(suite.T(), expected, obtained)
 }
 
 func (suite *RulesDocSuite) TestNotAny() {
 	rule := On(Not(Any)).Roles(uast.SimpleIdentifier)
-	expected := head + "| /self::*[not(*)] | SimpleIdentifier |\n"
+	expected := head + `| /self::\*\[not\(\*\)\] | SimpleIdentifier |` + "\n"
 	obtained := rule.String()
 	require.Equal(suite.T(), expected, obtained)
 }
 
 func (suite *RulesDocSuite) TestHasInternalType() {
 	rule := On(HasInternalType("foo")).Roles(uast.SimpleIdentifier)
-	expected := head + "| /self::*[@InternalType='foo'] | SimpleIdentifier |\n"
+	expected := head + `| /self::\*\[@InternalType='foo'\] | SimpleIdentifier |` + "\n"
 	obtained := rule.String()
 	require.Equal(suite.T(), expected, obtained)
 }
 
 func (suite *RulesDocSuite) TestHasProperty() {
 	rule := On(HasProperty("key", "value")).Roles(uast.SimpleIdentifier)
-	expected := head + "| /self::*[@key][@key='value'] | SimpleIdentifier |\n"
+	expected := head + `| /self::\*\[@key\]\[@key='value'\] | SimpleIdentifier |` + "\n"
 	obtained := rule.String()
 	require.Equal(suite.T(), expected, obtained)
 }
 
 func (suite *RulesDocSuite) TestHasInternalRole() {
 	rule := On(HasInternalRole("role")).Roles(uast.SimpleIdentifier)
-	expected := head + "| /self::*[@internalRole][@internalRole='role'] | SimpleIdentifier |\n"
+	expected := head + `| /self::\*\[@internalRole\]\[@internalRole='role'\] | SimpleIdentifier |` + "\n"
 	obtained := rule.String()
 	require.Equal(suite.T(), expected, obtained)
 }
 
 func (suite *RulesDocSuite) TestHasChild() {
 	rule := On(HasChild(HasInternalType("foo"))).Roles(uast.SimpleIdentifier)
-	expected := head + "| /self::*[child::@InternalType='foo'] | SimpleIdentifier |\n"
+	expected := head + `| /self::\*\[child::@InternalType='foo'\] | SimpleIdentifier |` + "\n"
 	obtained := rule.String()
 	require.Equal(suite.T(), expected, obtained)
 }
 
 func (suite *RulesDocSuite) TestToken() {
 	rule := On(HasToken("foo")).Roles(uast.SimpleIdentifier)
-	expected := head + "| /self::*[@Token='foo'] | SimpleIdentifier |\n"
+	expected := head + `| /self::\*\[@Token='foo'\] | SimpleIdentifier |` + "\n"
 	obtained := rule.String()
 	require.Equal(suite.T(), expected, obtained)
 }
@@ -75,7 +75,7 @@ func (suite *RulesDocSuite) TestAnd() {
 		HasInternalType("bla"),
 	)).Roles(uast.SimpleIdentifier)
 	expected := head +
-		"| /self::*[(@Token='foo') and (@Token='bar') and (@InternalType='bla')] | SimpleIdentifier |\n"
+		`| /self::\*\[\(@Token='foo'\) and \(@Token='bar'\) and \(@InternalType='bla'\)\] | SimpleIdentifier |` + "\n"
 	obtained := rule.String()
 	require.Equal(suite.T(), expected, obtained)
 }
@@ -87,40 +87,40 @@ func (suite *RulesDocSuite) TestOr() {
 		HasInternalType("bla"),
 	)).Roles(uast.SimpleIdentifier)
 	expected := head +
-		"| /self::*[(@Token='foo') or (@Token='bar') or (@InternalType='bla')] | SimpleIdentifier |\n"
+		`| /self::\*\[\(@Token='foo'\) or \(@Token='bar'\) or \(@InternalType='bla'\)\] | SimpleIdentifier |` + "\n"
 	obtained := rule.String()
 	require.Equal(suite.T(), expected, obtained)
 }
 
 func (suite *RulesDocSuite) TestSelf() {
 	rule := On(Any).Self(On(HasToken("foo")).Roles(uast.SimpleIdentifier))
-	expected := head + "| /self::*[@Token='foo'] | SimpleIdentifier |\n"
+	expected := head + `| /self::\*\[@Token='foo'\] | SimpleIdentifier |` + "\n"
 	obtained := rule.String()
 	require.Equal(suite.T(), expected, obtained)
 
 	rule = On(Any).Self(On(HasToken("foo"))).Roles(uast.SimpleIdentifier)
-	expected = head + "| /self::*[*] | SimpleIdentifier |\n"
+	expected = head + `| /self::\*\[\*\] | SimpleIdentifier |` + "\n"
 	obtained = rule.String()
 	require.Equal(suite.T(), expected, obtained)
 }
 
 func (suite *RulesDocSuite) TestChildren() {
 	rule := On(Any).Children(On(HasToken("foo")).Roles(uast.SimpleIdentifier))
-	expected := head + "| /*[@Token='foo'] | SimpleIdentifier |\n"
+	expected := head + `| /\*\[@Token='foo'\] | SimpleIdentifier |` + "\n"
 	obtained := rule.String()
 	require.Equal(suite.T(), expected, obtained)
 }
 
 func (suite *RulesDocSuite) TestDescendants() {
 	rule := On(Any).Descendants(On(HasToken("foo")).Roles(uast.SimpleIdentifier))
-	expected := head + "| //*[@Token='foo'] | SimpleIdentifier |\n"
+	expected := head + `| //\*\[@Token='foo'\] | SimpleIdentifier |` + "\n"
 	obtained := rule.String()
 	require.Equal(suite.T(), expected, obtained)
 }
 
 func (suite *RulesDocSuite) TestDescendantsOrSelf() {
 	rule := On(Any).DescendantsOrSelf(On(HasToken("foo")).Roles(uast.SimpleIdentifier))
-	expected := head + "| /descendant-or-self::*[@Token='foo'] | SimpleIdentifier |\n"
+	expected := head + `| /descendant\-or\-self::\*\[@Token='foo'\] | SimpleIdentifier |` + "\n"
 	obtained := rule.String()
 	require.Equal(suite.T(), expected, obtained)
 }
@@ -134,10 +134,53 @@ func (suite *RulesDocSuite) TestMisc1() {
 				On(HasInternalType("left")).Roles(uast.BinaryExpressionLeft)),
 		))
 	expected := head +
-		"| /self::*[not(@InternalType='FILE')] | Error |\n" +
-		"| /self::*[@InternalType='FILE'] | SimpleIdentifier |\n" +
-		"| /self::*[@InternalType='FILE']//*[@InternalType='identifier'] | QualifiedIdentifier |\n" +
-		"| /self::*[@InternalType='FILE']//*[@InternalType='binary expression']/*[@InternalType='left'] | BinaryExpressionLeft |\n"
+		`| /self::\*\[not\(@InternalType='FILE'\)\] | Error |` + "\n" +
+		`| /self::\*\[@InternalType='FILE'\] | SimpleIdentifier |` + "\n" +
+		`| /self::\*\[@InternalType='FILE'\]//\*\[@InternalType='identifier'\] | QualifiedIdentifier |` + "\n" +
+		`| /self::\*\[@InternalType='FILE'\]//\*\[@InternalType='binary expression'\]/\*\[@InternalType='left'\] | BinaryExpressionLeft |` + "\n"
+	obtained := rule.String()
+	require.Equal(suite.T(), expected, obtained)
+}
+
+func (suite *RulesDocSuite) TestMarkdownEscapes() {
+	rule := On(Any).Descendants(
+		On(HasInternalType(`\`)).Roles(uast.OpBooleanOr),
+		On(HasInternalType("|")).Roles(uast.OpBooleanOr),
+		On(HasInternalType("||")).Roles(uast.OpBooleanOr),
+		On(HasInternalType("`")).Roles(uast.OpBooleanOr),
+		On(HasInternalType("*")).Roles(uast.OpBooleanOr),
+		On(HasInternalType("_")).Roles(uast.OpBooleanOr),
+		On(HasInternalType("{")).Roles(uast.OpBooleanOr),
+		On(HasInternalType("}")).Roles(uast.OpBooleanOr),
+		On(HasInternalType("[")).Roles(uast.OpBooleanOr),
+		On(HasInternalType("]")).Roles(uast.OpBooleanOr),
+		On(HasInternalType("(")).Roles(uast.OpBooleanOr),
+		On(HasInternalType(")")).Roles(uast.OpBooleanOr),
+		On(HasInternalType("#")).Roles(uast.OpBooleanOr),
+		On(HasInternalType("+")).Roles(uast.OpBooleanOr),
+		On(HasInternalType("-")).Roles(uast.OpBooleanOr),
+		On(HasInternalType(".")).Roles(uast.OpBooleanOr),
+		On(HasInternalType("!")).Roles(uast.OpBooleanOr),
+	)
+	expected := head +
+		`| //\*\[@InternalType='\\'\] | OpBooleanOr |` + "\n" +
+		`| //\*\[@InternalType='\|'\] | OpBooleanOr |` + "\n" +
+		`| //\*\[@InternalType='\|\|'\] | OpBooleanOr |` + "\n" +
+		"| //\\*\\[@InternalType='`'\\] | OpBooleanOr |\n" +
+		`| //\*\[@InternalType='\*'\] | OpBooleanOr |` + "\n" +
+		`| //\*\[@InternalType='\_'\] | OpBooleanOr |` + "\n" +
+		`| //\*\[@InternalType='\{'\] | OpBooleanOr |` + "\n" +
+		`| //\*\[@InternalType='\}'\] | OpBooleanOr |` + "\n" +
+		`| //\*\[@InternalType='\['\] | OpBooleanOr |` + "\n" +
+		`| //\*\[@InternalType='\]'\] | OpBooleanOr |` + "\n" +
+		`| //\*\[@InternalType='\('\] | OpBooleanOr |` + "\n" +
+		`| //\*\[@InternalType='\)'\] | OpBooleanOr |` + "\n" +
+		`| //\*\[@InternalType='\#'\] | OpBooleanOr |` + "\n" +
+		`| //\*\[@InternalType='\+'\] | OpBooleanOr |` + "\n" +
+		`| //\*\[@InternalType='\-'\] | OpBooleanOr |` + "\n" +
+		`| //\*\[@InternalType='\.'\] | OpBooleanOr |` + "\n" +
+		`| //\*\[@InternalType='\!'\] | OpBooleanOr |` + "\n" +
+		""
 	obtained := rule.String()
 	require.Equal(suite.T(), expected, obtained)
 }

--- a/uast/ann/xpathdescription_test.go
+++ b/uast/ann/xpathdescription_test.go
@@ -1,0 +1,143 @@
+package ann
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/bblfsh/sdk/uast"
+	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
+)
+
+// go test -v -run 'TestNotationSuite' ./uast/ann
+
+type NotationSuite struct {
+	suite.Suite
+}
+
+func TestNotationSuite(t *testing.T) {
+	suite.Run(t, new(NotationSuite))
+}
+
+func (suite *NotationSuite) TestAny() {
+	rule := On(Any).Roles(uast.SimpleIdentifier)
+	expected := head + "| /self::*[*] | SimpleIdentifier |\n"
+	obtained := rule.String()
+	require.Equal(suite.T(), expected, obtained)
+}
+
+func (suite *NotationSuite) TestNotAny() {
+	rule := On(Not(Any)).Roles(uast.SimpleIdentifier)
+	expected := head + "| /self::*[not(*)] | SimpleIdentifier |\n"
+	obtained := rule.String()
+	require.Equal(suite.T(), expected, obtained)
+}
+
+func (suite *NotationSuite) TestHasInternalType() {
+	rule := On(HasInternalType("foo")).Roles(uast.SimpleIdentifier)
+	expected := head + "| /self::*[@InternalType='foo'] | SimpleIdentifier |\n"
+	obtained := rule.String()
+	require.Equal(suite.T(), expected, obtained)
+}
+
+func (suite *NotationSuite) TestHasProperty() {
+	rule := On(HasProperty("key", "value")).Roles(uast.SimpleIdentifier)
+	expected := head + "| /self::*[@key][@key='value'] | SimpleIdentifier |\n"
+	obtained := rule.String()
+	require.Equal(suite.T(), expected, obtained)
+}
+
+func (suite *NotationSuite) TestHasInternalRole() {
+	rule := On(HasInternalRole("role")).Roles(uast.SimpleIdentifier)
+	expected := head + "| /self::*[@internalRole][@internalRole='role'] | SimpleIdentifier |\n"
+	obtained := rule.String()
+	require.Equal(suite.T(), expected, obtained)
+}
+
+func (suite *NotationSuite) TestHasChild() {
+	rule := On(HasChild(HasInternalType("foo"))).Roles(uast.SimpleIdentifier)
+	expected := head + "| /self::*[child::@InternalType='foo'] | SimpleIdentifier |\n"
+	obtained := rule.String()
+	require.Equal(suite.T(), expected, obtained)
+}
+
+func (suite *NotationSuite) TestToken() {
+	rule := On(HasToken("foo")).Roles(uast.SimpleIdentifier)
+	expected := head + "| /self::*[@Token='foo'] | SimpleIdentifier |\n"
+	obtained := rule.String()
+	require.Equal(suite.T(), expected, obtained)
+}
+
+func (suite *NotationSuite) TestAnd() {
+	rule := On(And(
+		HasToken("foo"),
+		HasToken("bar"),
+		HasInternalType("bla"),
+	)).Roles(uast.SimpleIdentifier)
+	expected := head +
+		"| /self::*[(@Token='foo') and (@Token='bar') and (@InternalType='bla')] | SimpleIdentifier |\n"
+	obtained := rule.String()
+	require.Equal(suite.T(), expected, obtained)
+}
+
+func (suite *NotationSuite) TestOr() {
+	rule := On(Or(
+		HasToken("foo"),
+		HasToken("bar"),
+		HasInternalType("bla"),
+	)).Roles(uast.SimpleIdentifier)
+	expected := head +
+		"| /self::*[(@Token='foo') or (@Token='bar') or (@InternalType='bla')] | SimpleIdentifier |\n"
+	obtained := rule.String()
+	require.Equal(suite.T(), expected, obtained)
+}
+
+func (suite *NotationSuite) TestSelf() {
+	rule := On(Any).Self(On(HasToken("foo")).Roles(uast.SimpleIdentifier))
+	expected := head + "| /self::*[@Token='foo'] | SimpleIdentifier |\n"
+	obtained := rule.String()
+	require.Equal(suite.T(), expected, obtained)
+
+	rule = On(Any).Self(On(HasToken("foo"))).Roles(uast.SimpleIdentifier)
+	expected = head + "| /self::*[*] | SimpleIdentifier |\n"
+	obtained = rule.String()
+	require.Equal(suite.T(), expected, obtained)
+}
+
+func (suite *NotationSuite) TestChildren() {
+	rule := On(Any).Children(On(HasToken("foo")).Roles(uast.SimpleIdentifier))
+	expected := head + "| /*[@Token='foo'] | SimpleIdentifier |\n"
+	obtained := rule.String()
+	require.Equal(suite.T(), expected, obtained)
+}
+
+func (suite *NotationSuite) TestDescendants() {
+	rule := On(Any).Descendants(On(HasToken("foo")).Roles(uast.SimpleIdentifier))
+	expected := head + "| //*[@Token='foo'] | SimpleIdentifier |\n"
+	obtained := rule.String()
+	require.Equal(suite.T(), expected, obtained)
+}
+
+func (suite *NotationSuite) TestDescendantsOrSelf() {
+	rule := On(Any).DescendantsOrSelf(On(HasToken("foo")).Roles(uast.SimpleIdentifier))
+	expected := head + "| /descendant-or-self::*[@Token='foo'] | SimpleIdentifier |\n"
+	obtained := rule.String()
+	require.Equal(suite.T(), expected, obtained)
+}
+
+func (suite *NotationSuite) TestMisc1() {
+	rule := On(Any).Self(
+		On(Not(HasInternalType("FILE"))).Error(fmt.Errorf("root must be CompilationUnit")),
+		On(HasInternalType("FILE")).Roles(uast.SimpleIdentifier).Descendants(
+			On(HasInternalType("identifier")).Roles(uast.QualifiedIdentifier),
+			On(HasInternalType("binary expression")).Children(
+				On(HasInternalType("left")).Roles(uast.BinaryExpressionLeft)),
+		))
+	expected := head +
+		"| /self::*[not(@InternalType='FILE')] | Error |\n" +
+		"| /self::*[@InternalType='FILE'] | SimpleIdentifier |\n" +
+		"| /self::*[@InternalType='FILE']//*[@InternalType='identifier'] | QualifiedIdentifier |\n" +
+		"| /self::*[@InternalType='FILE']//*[@InternalType='binary expression']/*[@InternalType='left'] | BinaryExpressionLeft |\n"
+	obtained := rule.String()
+	require.Equal(suite.T(), expected, obtained)
+}

--- a/uast/ann/xpathdescription_test.go
+++ b/uast/ann/xpathdescription_test.go
@@ -9,66 +9,66 @@ import (
 	"github.com/stretchr/testify/suite"
 )
 
-// go test -v -run 'TestNotationSuite' ./uast/ann
+// go test -v -run 'TestRulesDocSuite' ./uast/ann
 
-type NotationSuite struct {
+type RulesDocSuite struct {
 	suite.Suite
 }
 
-func TestNotationSuite(t *testing.T) {
-	suite.Run(t, new(NotationSuite))
+func TestRulesDocSuite(t *testing.T) {
+	suite.Run(t, new(RulesDocSuite))
 }
 
-func (suite *NotationSuite) TestAny() {
+func (suite *RulesDocSuite) TestAny() {
 	rule := On(Any).Roles(uast.SimpleIdentifier)
 	expected := head + "| /self::*[*] | SimpleIdentifier |\n"
 	obtained := rule.String()
 	require.Equal(suite.T(), expected, obtained)
 }
 
-func (suite *NotationSuite) TestNotAny() {
+func (suite *RulesDocSuite) TestNotAny() {
 	rule := On(Not(Any)).Roles(uast.SimpleIdentifier)
 	expected := head + "| /self::*[not(*)] | SimpleIdentifier |\n"
 	obtained := rule.String()
 	require.Equal(suite.T(), expected, obtained)
 }
 
-func (suite *NotationSuite) TestHasInternalType() {
+func (suite *RulesDocSuite) TestHasInternalType() {
 	rule := On(HasInternalType("foo")).Roles(uast.SimpleIdentifier)
 	expected := head + "| /self::*[@InternalType='foo'] | SimpleIdentifier |\n"
 	obtained := rule.String()
 	require.Equal(suite.T(), expected, obtained)
 }
 
-func (suite *NotationSuite) TestHasProperty() {
+func (suite *RulesDocSuite) TestHasProperty() {
 	rule := On(HasProperty("key", "value")).Roles(uast.SimpleIdentifier)
 	expected := head + "| /self::*[@key][@key='value'] | SimpleIdentifier |\n"
 	obtained := rule.String()
 	require.Equal(suite.T(), expected, obtained)
 }
 
-func (suite *NotationSuite) TestHasInternalRole() {
+func (suite *RulesDocSuite) TestHasInternalRole() {
 	rule := On(HasInternalRole("role")).Roles(uast.SimpleIdentifier)
 	expected := head + "| /self::*[@internalRole][@internalRole='role'] | SimpleIdentifier |\n"
 	obtained := rule.String()
 	require.Equal(suite.T(), expected, obtained)
 }
 
-func (suite *NotationSuite) TestHasChild() {
+func (suite *RulesDocSuite) TestHasChild() {
 	rule := On(HasChild(HasInternalType("foo"))).Roles(uast.SimpleIdentifier)
 	expected := head + "| /self::*[child::@InternalType='foo'] | SimpleIdentifier |\n"
 	obtained := rule.String()
 	require.Equal(suite.T(), expected, obtained)
 }
 
-func (suite *NotationSuite) TestToken() {
+func (suite *RulesDocSuite) TestToken() {
 	rule := On(HasToken("foo")).Roles(uast.SimpleIdentifier)
 	expected := head + "| /self::*[@Token='foo'] | SimpleIdentifier |\n"
 	obtained := rule.String()
 	require.Equal(suite.T(), expected, obtained)
 }
 
-func (suite *NotationSuite) TestAnd() {
+func (suite *RulesDocSuite) TestAnd() {
 	rule := On(And(
 		HasToken("foo"),
 		HasToken("bar"),
@@ -80,7 +80,7 @@ func (suite *NotationSuite) TestAnd() {
 	require.Equal(suite.T(), expected, obtained)
 }
 
-func (suite *NotationSuite) TestOr() {
+func (suite *RulesDocSuite) TestOr() {
 	rule := On(Or(
 		HasToken("foo"),
 		HasToken("bar"),
@@ -92,7 +92,7 @@ func (suite *NotationSuite) TestOr() {
 	require.Equal(suite.T(), expected, obtained)
 }
 
-func (suite *NotationSuite) TestSelf() {
+func (suite *RulesDocSuite) TestSelf() {
 	rule := On(Any).Self(On(HasToken("foo")).Roles(uast.SimpleIdentifier))
 	expected := head + "| /self::*[@Token='foo'] | SimpleIdentifier |\n"
 	obtained := rule.String()
@@ -104,28 +104,28 @@ func (suite *NotationSuite) TestSelf() {
 	require.Equal(suite.T(), expected, obtained)
 }
 
-func (suite *NotationSuite) TestChildren() {
+func (suite *RulesDocSuite) TestChildren() {
 	rule := On(Any).Children(On(HasToken("foo")).Roles(uast.SimpleIdentifier))
 	expected := head + "| /*[@Token='foo'] | SimpleIdentifier |\n"
 	obtained := rule.String()
 	require.Equal(suite.T(), expected, obtained)
 }
 
-func (suite *NotationSuite) TestDescendants() {
+func (suite *RulesDocSuite) TestDescendants() {
 	rule := On(Any).Descendants(On(HasToken("foo")).Roles(uast.SimpleIdentifier))
 	expected := head + "| //*[@Token='foo'] | SimpleIdentifier |\n"
 	obtained := rule.String()
 	require.Equal(suite.T(), expected, obtained)
 }
 
-func (suite *NotationSuite) TestDescendantsOrSelf() {
+func (suite *RulesDocSuite) TestDescendantsOrSelf() {
 	rule := On(Any).DescendantsOrSelf(On(HasToken("foo")).Roles(uast.SimpleIdentifier))
 	expected := head + "| /descendant-or-self::*[@Token='foo'] | SimpleIdentifier |\n"
 	obtained := rule.String()
 	require.Equal(suite.T(), expected, obtained)
 }
 
-func (suite *NotationSuite) TestMisc1() {
+func (suite *RulesDocSuite) TestMisc1() {
 	rule := On(Any).Self(
 		On(Not(HasInternalType("FILE"))).Error(fmt.Errorf("root must be CompilationUnit")),
 		On(HasInternalType("FILE")).Roles(uast.SimpleIdentifier).Descendants(


### PR DESCRIPTION
Fixes https://github.com/src-d/backlog/issues/701.

- ann: Add Rule.String to create markdown tables using XPath like notation

  Every predicate is now a type, implementing the new Predicate interface
  and they know how to print themselves in XPath-like notation.

  The processing of the rule tree is implemented as a folding operation
  by the new xPathDescription type.

- makefile: Add new docgen target

  This adds the new rule `docgen` to the makefile, that generates
  documentation for the driver.

  It also adds docgen as a prerequisite to build.

  Right now it only prints the rules as a markdown table to a ANNOTATION.md file.