### PR TITLE
Increase JSON decoder buffer size to 4Mb

### DIFF
--- a/protocol/jsonlines/decoder.go
+++ b/protocol/jsonlines/decoder.go
@@ -10,7 +10,7 @@ import (
 const (
 	// DefaultBufferSize is the default buffer size for decoding. It will
 	// be used whenever the given reader is not buffered.
-	DefaultBufferSize = 1024 * 1024
+	DefaultBufferSize = 1024 * 1024 * 4
 )
 
 type lineReader interface {


### PR DESCRIPTION
This fix all "buffer size excedeed" problems with all the Python files I tested (all of the modules in Python 2.7 and 3.6 stdlibs, including some huge ones) but eventually a dynamic allocation alternative will be needed.