### PR TITLE
Adds and remove the Unannotated status to nodes

### DIFF
--- a/uast/ann/ann.go
+++ b/uast/ann/ann.go
@@ -31,7 +31,7 @@ func (a axis) String() string {
 	case descendantOrSelf:
 		return "descendant-or-self"
 	default:
-		panic(fmt.Sprintf("unknown axis: %q", a))
+		panic(fmt.Sprintf("unknown axis: %q", int(a)))
 	}
 }
 
@@ -363,6 +363,9 @@ func AddRoles(roles ...uast.Role) Action {
 	}
 	return &action{
 		do: func(n *uast.Node) error {
+			if len(n.Roles) > 0 && n.Roles[0] == uast.Unannotated {
+				n.Roles = n.Roles[:0]
+			}
 			n.Roles = append(n.Roles, roles...)
 			return nil
 		},

--- a/uast/ann/ann_test.go
+++ b/uast/ann/ann_test.go
@@ -201,8 +201,10 @@ func TestRuleOnApply(t *testing.T) {
 
 	input := &Node{
 		InternalType: "root",
+		Roles: []Role{Unannotated},
 		Children: []*Node{{
 			InternalType: "foo",
+			Roles: []Role{Unannotated},
 		}},
 	}
 	expected := &Node{
@@ -210,6 +212,7 @@ func TestRuleOnApply(t *testing.T) {
 		Roles:        []Role{role},
 		Children: []*Node{{
 			InternalType: "foo",
+			Roles: []Role{Unannotated},
 		}},
 	}
 	err := rule.Apply(input)
@@ -225,12 +228,16 @@ func TestRuleOnSelfApply(t *testing.T) {
 
 	input := &Node{
 		InternalType: "root",
+		Roles: []Role{Unannotated},
 		Children: []*Node{{
 			InternalType: "foo",
+			Roles: []Role{Unannotated},
 			Children: []*Node{{
 				InternalType: "bar",
+				Roles: []Role{Unannotated},
 				Children: []*Node{{
 					InternalType: "baz",
+					Roles: []Role{Unannotated},
 				}},
 			}},
 		}},
@@ -240,10 +247,13 @@ func TestRuleOnSelfApply(t *testing.T) {
 		Roles:        []Role{role},
 		Children: []*Node{{
 			InternalType: "foo",
+			Roles: []Role{Unannotated},
 			Children: []*Node{{
 				InternalType: "bar",
+				Roles: []Role{Unannotated},
 				Children: []*Node{{
 					InternalType: "baz",
+					Roles: []Role{Unannotated},
 				}},
 			}},
 		}},
@@ -261,12 +271,15 @@ func TestRuleOnChildrenApply(t *testing.T) {
 
 	input := &Node{
 		InternalType: "root",
+		Roles: []Role{Unannotated},
 		Children: []*Node{{
 			InternalType: "foo",
+			Roles: []Role{Unannotated},
 		}},
 	}
 	expected := &Node{
 		InternalType: "root",
+		Roles: []Role{Unannotated},
 		Children: []*Node{{
 			InternalType: "foo",
 			Roles:        []Role{role},
@@ -278,14 +291,18 @@ func TestRuleOnChildrenApply(t *testing.T) {
 
 	input = &Node{
 		InternalType: "foo",
+		Roles: []Role{Unannotated},
 		Children: []*Node{{
 			InternalType: "bar",
+			Roles: []Role{Unannotated},
 		}},
 	}
 	expected = &Node{
 		InternalType: "foo",
+		Roles: []Role{Unannotated},
 		Children: []*Node{{
 			InternalType: "bar",
+			Roles: []Role{Unannotated},
 		}},
 	}
 	err = rule.Apply(input)
@@ -294,19 +311,25 @@ func TestRuleOnChildrenApply(t *testing.T) {
 
 	input = &Node{
 		InternalType: "foo",
+		Roles: []Role{Unannotated},
 		Children: []*Node{{
 			InternalType: "bar",
+			Roles: []Role{Unannotated},
 			Children: []*Node{{
 				InternalType: "foo",
+				Roles: []Role{Unannotated},
 			}},
 		}},
 	}
 	expected = &Node{
 		InternalType: "foo",
+		Roles: []Role{Unannotated},
 		Children: []*Node{{
 			InternalType: "bar",
+			Roles: []Role{Unannotated},
 			Children: []*Node{{
 				InternalType: "foo",
+				Roles: []Role{Unannotated},
 			}},
 		}},
 	}
@@ -323,12 +346,15 @@ func TestRuleOnDescendantsApply(t *testing.T) {
 
 	input := &Node{
 		InternalType: "root",
+		Roles: []Role{Unannotated},
 		Children: []*Node{{
 			InternalType: "foo",
+			Roles: []Role{Unannotated},
 		}},
 	}
 	expected := &Node{
 		InternalType: "root",
+		Roles: []Role{Unannotated},
 		Children: []*Node{{
 			InternalType: "foo",
 			Roles:        []Role{role},
@@ -340,14 +366,18 @@ func TestRuleOnDescendantsApply(t *testing.T) {
 
 	input = &Node{
 		InternalType: "foo",
+		Roles: []Role{Unannotated},
 		Children: []*Node{{
 			InternalType: "bar",
+			Roles: []Role{Unannotated},
 		}},
 	}
 	expected = &Node{
 		InternalType: "foo",
+		Roles: []Role{Unannotated},
 		Children: []*Node{{
 			InternalType: "bar",
+			Roles: []Role{Unannotated},
 		}},
 	}
 	err = rule.Apply(input)
@@ -356,17 +386,22 @@ func TestRuleOnDescendantsApply(t *testing.T) {
 
 	input = &Node{
 		InternalType: "foo",
+		Roles: []Role{Unannotated},
 		Children: []*Node{{
 			InternalType: "bar",
+			Roles: []Role{Unannotated},
 			Children: []*Node{{
 				InternalType: "foo",
+				Roles: []Role{Unannotated},
 			}},
 		}},
 	}
 	expected = &Node{
 		InternalType: "foo",
+		Roles: []Role{Unannotated},
 		Children: []*Node{{
 			InternalType: "bar",
+			Roles: []Role{Unannotated},
 			Children: []*Node{{
 				InternalType: "foo",
 				Roles:        []Role{role},
@@ -386,12 +421,15 @@ func TestRuleOnDescendantsOrSelfApply(t *testing.T) {
 
 	input := &Node{
 		InternalType: "root",
+		Roles: []Role{Unannotated},
 		Children: []*Node{{
 			InternalType: "foo",
+			Roles: []Role{Unannotated},
 		}},
 	}
 	expected := &Node{
 		InternalType: "root",
+		Roles: []Role{Unannotated},
 		Children: []*Node{{
 			InternalType: "foo",
 			Roles:        []Role{role},
@@ -403,10 +441,13 @@ func TestRuleOnDescendantsOrSelfApply(t *testing.T) {
 
 	input = &Node{
 		InternalType: "foo",
+		Roles: []Role{Unannotated},
 		Children: []*Node{{
 			InternalType: "bar",
+			Roles: []Role{Unannotated},
 			Children: []*Node{{
 				InternalType: "foo",
+				Roles: []Role{Unannotated},
 			}},
 		}},
 	}
@@ -415,6 +456,7 @@ func TestRuleOnDescendantsOrSelfApply(t *testing.T) {
 		Roles:        []Role{role},
 		Children: []*Node{{
 			InternalType: "bar",
+			Roles: []Role{Unannotated},
 			Children: []*Node{{
 				InternalType: "foo",
 				Roles:        []Role{role},
@@ -435,8 +477,10 @@ func TestRuleOnRulesActionError(t *testing.T) {
 
 	input := &Node{
 		InternalType: "root",
+		Roles: []Role{Unannotated},
 		Children: []*Node{{
 			InternalType: "foo",
+			Roles: []Role{Unannotated},
 		}},
 	}
 	err := rule.Apply(input)

--- a/uast/uast.go
+++ b/uast/uast.go
@@ -526,6 +526,7 @@ type Node struct {
 func NewNode() *Node {
 	return &Node{
 		Properties: make(map[string]string, 0),
+		Roles: []Role{Unannotated},
 	}
 }
 


### PR DESCRIPTION
- `NewNode()` will add the Unannotated role to all new nodes by default, `AddRoles()` will remove it the first time another role is added. I also tried the other way, that is, adding `Unannotated` when a Node has no roles after `Apply()` but since it also runs over the children recursively it was more complicated (it had to check and remove the `Unannotated` node anyway).

- Tests updated. Also tested with the Python and Java driver integration tests (next PRs will update those).

- Fixes an unrelated bug from a previous commit of a possible recursive `axis.String` call that my linter catched.