### PR TITLE
New feature to promote string properties to nodes

### DIFF
--- a/protocol/native/objecttonoder_test.go
+++ b/protocol/native/objecttonoder_test.go
@@ -158,6 +158,44 @@ func TestPropertyListPromotionSpecific(t *testing.T) {
 	n, err = p.ToNode(f)
 	require.NoError(err)
 	require.NotNil(n)
+
+	child = findChildWithInternalType(n, "CompilationUnit.types")
+	require.NotNil(child)
+}
+
+// Test for promoting a property with a string value to its own node
+func TestPropertyString(t *testing.T) {
+	require := require.New(t)
+
+	f, err := getFixture("java_example_1.json")
+	require.NoError(err)
+
+	p := &ObjectToNoder{
+		InternalTypeKey: "internalClass",
+		LineKey:         "line",
+	}
+	n, err := p.ToNode(f)
+	require.NoError(err)
+	require.NotNil(n)
+
+	child := findChildWithInternalType(n, "CompilationUnit.internalClass")
+	require.Nil(child)
+
+	p = &ObjectToNoder{
+		InternalTypeKey: "internalClass",
+		LineKey:         "line",
+		PromotedPropertyStrings: map[string]map[string]bool{
+			"CompilationUnit": {"internalClass": true},
+		},
+	}
+
+	n, err = p.ToNode(f)
+	require.NoError(err)
+	require.NotNil(n)
+
+	child = findChildWithInternalType(n, "CompilationUnit.internalClass")
+	require.NotNil(child)
+	require.Equal(child.Token, "CompilationUnit")
 }
 
 // Test promoting all property-list elements to its own node


### PR DESCRIPTION
New feature to promote string properties to full nodes, similar to the existing one that allows to promote the keys in properties holding arrays to nodes.

Like in the previous case the key name will be the `internalType` and the string value will be set as the node `Token`.

This allows to convert something like:

```python
import numpy as np
```

With native (simplified) AST:

```python
                        {
                            "ast_type": "alias",
                            "asname": "np",
                            "name": "numpy"
                        }
```

To this (simplified & prettified) UAST:
                 
```python
{
  .  .  .  .  .  Roles: ImportPath,SimpleIdentifier
  .  .  .  .  .  TOKEN "numpy"
  .  .  .  .  .  Children: {
  .  .  .  .  .  .  0: alias.asname {
  .  .  .  .  .  .  .  Roles: ImportAlias,SimpleIdentifier
  .  .  .  .  .  .  .  TOKEN "np"
  .  .  .  .  .  .  .  Properties: {
  .  .  .  .  .  .  .  .  promotedPropertyString: true
  .  .  .  .  .  .  .  }
  .  .  .  .  .  .  }
  .  .  .  .  .  }
}
```