### PR TITLE
objecttonoder: Use a different proper name for promoted string keys

### DIFF
--- a/protocol/native/objecttonoder.go
+++ b/protocol/native/objecttonoder.go
@@ -203,8 +203,10 @@ func (c *ObjectToNoder) toNode(obj interface{}) (*uast.Node, error) {
 
 			n.Children = append(n.Children, children...)
 		default:
+			newKey := k
 			if s, ok := o.(string); ok {
 				if len(s) > 0 && promotedStrKeys != nil && promotedStrKeys[k] {
+					newKey = internalKey + "." + k
 					child := c.stringToNode(k, s, internalKey)
 					if child != nil {
 						n.Children = append(n.Children, child)
@@ -212,7 +214,7 @@ func (c *ObjectToNoder) toNode(obj interface{}) (*uast.Node, error) {
 				}
 			}
 
-			if err := c.addProperty(n, k, o); err != nil {
+			if err := c.addProperty(n, newKey, o); err != nil {
 				return nil, err
 			}
 		}


### PR DESCRIPTION
Currently new nodes are promoted and include the same property name, which are usually included in `TokenKeys` and this causes these nodes to include the token by default, which is then duplicated and used in this parent umbrella node where they shouldn't.

This change renames the property, allowing it to be handled independently.