### PR TITLE
New ToNoder option to fill missing position elements. Unified parser.go skeleton.

### DIFF
--- a/assets/skeleton/bindata.go
+++ b/assets/skeleton/bindata.go
@@ -1045,12 +1045,29 @@ import (
 	"github.com/bblfsh/sdk/protocol/native"
 )
 
+// ToNoder specifies the driver options. Driver programmers should fill it
+var ToNoder = &native.ObjectToNoder{}
+
 // ParserBuilder creates a parser that transform source code files into *uast.Node.
-func ParserBuilder(opts driver.ParserOptions) (driver.Parser, error) {
-	toNoder := &native.ObjectToNoder{}
-	parser, err := native.ExecParser(toNoder, opts.NativeBin)
+func ParserBuilder(opts driver.ParserOptions) (parser driver.Parser, err error) {
+	psr, err := native.ExecParser(ToNoder, opts.NativeBin)
 	if err != nil {
-		return nil, err
+		return psr, err
+	}
+
+	switch ToNoder.PositionFill {
+	case native.None:
+		parser = psr
+	case native.OffsetFromLineCol:
+		parser = &driver.TransformationParser{
+			Parser:         psr,
+			Transformation: driver.FillOffsetFromLineCol,
+		}
+	case native.LineColFromOffset:
+		parser = &driver.TransformationParser{
+			Parser:         psr,
+			Transformation: driver.FillLineColFromOffset,
+		}
 	}
 
 	return parser, nil
@@ -1067,7 +1084,7 @@ func driverNormalizerParserGo() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "driver/normalizer/parser.go", size: 425, mode: os.FileMode(420), modTime: time.Unix(1, 0)}
+	info := bindataFileInfo{name: "driver/normalizer/parser.go", size: 880, mode: os.FileMode(420), modTime: time.Unix(1, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }

--- a/assets/skeleton/bindata.go
+++ b/assets/skeleton/bindata.go
@@ -1050,27 +1050,25 @@ var ToNoder = &native.ObjectToNoder{}
 
 // ParserBuilder creates a parser that transform source code files into *uast.Node.
 func ParserBuilder(opts driver.ParserOptions) (parser driver.Parser, err error) {
-	psr, err := native.ExecParser(ToNoder, opts.NativeBin)
+	parser, err = native.ExecParser(ToNoder, opts.NativeBin)
 	if err != nil {
-		return psr, err
+		return
 	}
 
 	switch ToNoder.PositionFill {
-	case native.None:
-		parser = psr
 	case native.OffsetFromLineCol:
 		parser = &driver.TransformationParser{
-			Parser:         psr,
+			Parser:         parser,
 			Transformation: driver.FillOffsetFromLineCol,
 		}
 	case native.LineColFromOffset:
 		parser = &driver.TransformationParser{
-			Parser:         psr,
+			Parser:         parser,
 			Transformation: driver.FillLineColFromOffset,
 		}
 	}
 
-	return parser, nil
+	return
 }
 `)
 
@@ -1084,7 +1082,7 @@ func driverNormalizerParserGo() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "driver/normalizer/parser.go", size: 880, mode: os.FileMode(420), modTime: time.Unix(1, 0)}
+	info := bindataFileInfo{name: "driver/normalizer/parser.go", size: 833, mode: os.FileMode(420), modTime: time.Unix(1, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }

--- a/etc/skeleton/driver/normalizer/parser.go
+++ b/etc/skeleton/driver/normalizer/parser.go
@@ -10,25 +10,23 @@ var ToNoder = &native.ObjectToNoder{}
 
 // ParserBuilder creates a parser that transform source code files into *uast.Node.
 func ParserBuilder(opts driver.ParserOptions) (parser driver.Parser, err error) {
-	psr, err := native.ExecParser(ToNoder, opts.NativeBin)
+	parser, err = native.ExecParser(ToNoder, opts.NativeBin)
 	if err != nil {
-		return psr, err
+		return
 	}
 
 	switch ToNoder.PositionFill {
-	case native.None:
-		parser = psr
 	case native.OffsetFromLineCol:
 		parser = &driver.TransformationParser{
-			Parser:         psr,
+			Parser:         parser,
 			Transformation: driver.FillOffsetFromLineCol,
 		}
 	case native.LineColFromOffset:
 		parser = &driver.TransformationParser{
-			Parser:         psr,
+			Parser:         parser,
 			Transformation: driver.FillLineColFromOffset,
 		}
 	}
 
-	return parser, nil
+	return
 }

--- a/etc/skeleton/driver/normalizer/parser.go
+++ b/etc/skeleton/driver/normalizer/parser.go
@@ -5,6 +5,9 @@ import (
 	"github.com/bblfsh/sdk/protocol/native"
 )
 
+// ToNoder specifies the driver options. Driver programmers should fill it
+var ToNoder = &native.ObjectToNoder{}
+
 // ParserBuilder creates a parser that transform source code files into *uast.Node.
 func ParserBuilder(opts driver.ParserOptions) (parser driver.Parser, err error) {
 	psr, err := native.ExecParser(ToNoder, opts.NativeBin)

--- a/etc/skeleton/driver/normalizer/parser.go
+++ b/etc/skeleton/driver/normalizer/parser.go
@@ -6,11 +6,25 @@ import (
 )
 
 // ParserBuilder creates a parser that transform source code files into *uast.Node.
-func ParserBuilder(opts driver.ParserOptions) (driver.Parser, error) {
-	toNoder := &native.ObjectToNoder{}
-	parser, err := native.ExecParser(toNoder, opts.NativeBin)
+func ParserBuilder(opts driver.ParserOptions) (parser driver.Parser, err error) {
+	psr, err := native.ExecParser(ToNoder, opts.NativeBin)
 	if err != nil {
-		return nil, err
+		return psr, err
+	}
+
+	switch ToNoder.PositionFill {
+	case native.None:
+		parser = psr
+	case native.OffsetFromLineCol:
+		parser = &driver.TransformationParser{
+			Parser:         psr,
+			Transformation: driver.FillOffsetFromLineCol,
+		}
+	case native.LineColFromOffset:
+		parser = &driver.TransformationParser{
+			Parser:         psr,
+			Transformation: driver.FillLineColFromOffset,
+		}
 	}
 
 	return parser, nil

--- a/protocol/native/objecttonoder.go
+++ b/protocol/native/objecttonoder.go
@@ -19,6 +19,13 @@ var (
 	ErrUnsupported          = errors.NewKind("unsupported: %s")
 )
 
+type FillType int
+const (
+	None FillType = iota
+	OffsetFromLineCol
+	LineColFromOffset
+)
+
 // ObjectToNoder is a ToNoder for trees that are represented as nested JSON objects.
 // That is, an interface{} containing maps, slices, strings and integers. It
 // then converts from that structure to *Node.
@@ -99,6 +106,11 @@ type ObjectToNoder struct {
 	// the root will be the value of the only key present in its input
 	// argument.
 	TopLevelIsRootNode bool
+	// PositionFill specifies if the noder has to fill missing positions (col, line, offset)
+	// from ones that the native AST fills. The possible values are "None" (don't fill
+	// anything), "OffsetFromLineCol" (fill the offset from the line and column values) and
+	// "LineColFromOffset" (fill line and col from the offset).
+	PositionFill FillType
 }
 
 func (c *ObjectToNoder) ToNode(v interface{}) (*uast.Node, error) {


### PR DESCRIPTION
Part of src-d/backlog/issues/889