### PR TITLE
server: logger configurations

### DIFF
--- a/sdk/driver/common.go
+++ b/sdk/driver/common.go
@@ -1,0 +1,16 @@
+// Package driver contains all the logic to build a driver.
+package driver
+
+import "gopkg.in/bblfsh/sdk.v1/manifest"
+
+var (
+	// DriverBinary default location of the driver binary. Should not
+	// override this variable unless you know what are you doing.
+	DriverBinary = "/opt/driver/bin/driver"
+	// NativeBinary default location of the native driver binary. Should not
+	// override this variable unless you know what are you doing.
+	NativeBinary = "/opt/driver/bin/native"
+	// ManifestLocation location of the manifest file. Should not override
+	// this variable unless you know what are you doing.
+	ManifestLocation = "/opt/driver/etc/" + manifest.Filename
+)

--- a/sdk/driver/driver.go
+++ b/sdk/driver/driver.go
@@ -10,12 +10,6 @@ import (
 	"gopkg.in/bblfsh/sdk.v1/uast/transformer"
 )
 
-var (
-	// ManifestLocation location of the manifest file. Should not override
-	// this variable unless you know what are you doing.
-	ManifestLocation = "/opt/driver/etc/" + manifest.Filename
-)
-
 // Driver implements a bblfsh driver, a driver is on charge of transforming a
 // source code into an AST and a UAST. To transform the AST into a UAST, a
 // `uast.ObjectToNode`` and a series of `tranformer.Transformer` are used.

--- a/sdk/driver/native.go
+++ b/sdk/driver/native.go
@@ -16,9 +16,7 @@ import (
 )
 
 var (
-	// NativeBinary default location of the native driver binary. Should not
-	// override this variable unless you know what are you doing.
-	NativeBinary = "/opt/driver/bin/native"
+
 
 	ErrUnsupportedLanguage = errors.NewKind("unsupported language got %q, expected %q")
 	ErrNativeNotRunning    = errors.NewKind("native driver is not running")

--- a/sdk/server/logger.go
+++ b/sdk/server/logger.go
@@ -1,0 +1,77 @@
+package server
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/sirupsen/logrus"
+	"github.com/x-cray/logrus-prefixed-formatter"
+)
+
+// Logger represents a generic logger, based on logrus.Logger
+type Logger interface {
+	Debugf(format string, args ...interface{})
+	Errorf(format string, args ...interface{})
+	Fatalf(format string, args ...interface{})
+	Infof(format string, args ...interface{})
+	Warningf(format string, args ...interface{})
+}
+
+// LoggerFactory is a helper for create logrus.Logger's
+type LoggerFactory struct {
+	Level  string
+	Fields string
+	Format string
+}
+
+func (c LoggerFactory) New() (Logger, error) {
+	l := logrus.New()
+	if err := c.setLevel(l); err != nil {
+		return nil, err
+	}
+
+	if err := c.setFormat(l); err != nil {
+		return nil, err
+	}
+
+	return c.setFields(l)
+}
+
+func (c LoggerFactory) setLevel(l *logrus.Logger) error {
+	level, err := logrus.ParseLevel(c.Level)
+	if err != nil {
+		return err
+	}
+
+	l.Level = level
+	return nil
+}
+
+func (c LoggerFactory) setFormat(l *logrus.Logger) error {
+	switch c.Format {
+	case "text":
+		f := new(prefixed.TextFormatter)
+		f.ForceColors = true
+		f.FullTimestamp = true
+		l.Formatter = f
+	case "json":
+		l.Formatter = new(logrus.JSONFormatter)
+	default:
+		return fmt.Errorf("unknown logger format: %q", c.Format)
+	}
+
+	return nil
+}
+
+func (c *LoggerFactory) setFields(l *logrus.Logger) (Logger, error) {
+	if c.Fields == "" {
+		return l, nil
+	}
+
+	var fields logrus.Fields
+	if err := json.Unmarshal([]byte(c.Fields), &fields); err != nil {
+		return nil, err
+	}
+
+	return l.WithFields(fields), nil
+}

--- a/sdk/server/server.go
+++ b/sdk/server/server.go
@@ -5,7 +5,6 @@ import (
 
 	"gopkg.in/bblfsh/sdk.v1/protocol"
 
-	"github.com/sirupsen/logrus"
 	"google.golang.org/grpc"
 	"gopkg.in/src-d/go-errors.v1"
 )
@@ -19,7 +18,7 @@ type Server struct {
 	// Options list of grpc.ServerOption's.
 	Options []grpc.ServerOption
 	// Logger a logger to be used by the server.
-	Logger *logrus.Logger
+	Logger Logger
 
 	*grpc.Server
 }
@@ -32,7 +31,7 @@ func (s *Server) Serve(listener net.Listener) error {
 	}
 
 	defer func() {
-		s.Logger.Info("grpc server ready")
+		s.Logger.Infof("grpc server ready")
 	}()
 
 	return s.Server.Serve(listener)
@@ -45,7 +44,7 @@ func (s *Server) initialize() error {
 
 	s.Server = grpc.NewServer(s.Options...)
 
-	s.Logger.Debug("registering grpc service")
+	s.Logger.Debugf("registering grpc service")
 	protocol.RegisterProtocolServiceServer(
 		s.Server,
 		protocol.NewProtocolServiceServer(),


### PR DESCRIPTION
In order to improve the logging in server and clients, I created a `LoggerFactory` and `Logger` interface to use exactly the same configuration in the drivers and server.

With the goal of miss the outputs of all the driver and server, I added too the "-log-fields", to pass information to the driver to log togetther the common line "

```
 $ python driver --log-level debug --log-format text --log-fields '{"language":"python", "container":"AABBCCDD"}'
[2017-09-28T13:48:13Z]  INFO python-driver version: dev-0b6ddb4-dirty (build: 2017-09-28T13:45:46Z) container=AABBCCDD language=python
[2017-09-28T13:48:13Z] DEBUG executing native binary ... container=AABBCCDD language=python
[2017-09-28T13:48:13Z]  INFO server listening in localhost:9432 (tcp) container=AABBCCDD language=python
[2017-09-28T13:48:13Z] DEBUG registering grpc service container=AABBCCDD language=python
```
Also I added the option `--log-format` to force when or when not we want use json format. 