### PR TITLE
sdk: server.LoggerFactory added Apply method to modify the standard logrus logger

### DIFF
--- a/sdk/server/logger.go
+++ b/sdk/server/logger.go
@@ -24,6 +24,7 @@ type LoggerFactory struct {
 	Format string
 }
 
+// New returns a new logger based on the LoggerFactory values.
 func (c LoggerFactory) New() (Logger, error) {
 	l := logrus.New()
 	if err := c.setLevel(l); err != nil {
@@ -35,6 +36,15 @@ func (c LoggerFactory) New() (Logger, error) {
 	}
 
 	return c.setFields(l)
+}
+
+// Apply configures the standard logrus Logger with the LoggerFactory values.
+func (c LoggerFactory) Apply() error {
+	if err := c.setLevel(logrus.StandardLogger()); err != nil {
+		return err
+	}
+
+	return c.setFormat(logrus.StandardLogger())
 }
 
 func (c LoggerFactory) setLevel(l *logrus.Logger) error {

--- a/sdk/server/logger_test.go
+++ b/sdk/server/logger_test.go
@@ -1,0 +1,90 @@
+package server
+
+import (
+	"testing"
+
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/require"
+	prefixed "github.com/x-cray/logrus-prefixed-formatter"
+)
+
+func TestLoggerFactoryNew_Text(t *testing.T) {
+	require := require.New(t)
+
+	f := &LoggerFactory{Format: "text", Level: "debug"}
+	logger, err := f.New()
+	require.NoError(err)
+
+	llogrus, ok := logger.(*logrus.Logger)
+	require.True(ok)
+	require.IsType(&prefixed.TextFormatter{}, llogrus.Formatter)
+	require.Equal(logrus.DebugLevel, llogrus.Level)
+}
+
+func TestLoggerFactoryNew_JSON(t *testing.T) {
+	require := require.New(t)
+
+	f := &LoggerFactory{Format: "json", Level: "info"}
+	logger, err := f.New()
+	require.NoError(err)
+
+	llogrus, ok := logger.(*logrus.Logger)
+	require.True(ok)
+	require.IsType(&logrus.JSONFormatter{}, llogrus.Formatter)
+	require.Equal(logrus.InfoLevel, llogrus.Level)
+}
+
+func TestLoggerFactoryNew_Fields(t *testing.T) {
+	require := require.New(t)
+
+	js := `{"foo":"bar"}`
+	f := &LoggerFactory{Format: "text", Level: "debug", Fields: js}
+	logger, err := f.New()
+	require.NoError(err)
+
+	entry, ok := logger.(*logrus.Entry)
+	require.True(ok)
+	require.IsType(&prefixed.TextFormatter{}, entry.Logger.Formatter)
+	require.Equal(logrus.DebugLevel, entry.Logger.Level)
+	require.Equal(logrus.Fields{"foo": "bar"}, entry.Data)
+}
+
+func TestLoggerFactoryNew_Error(t *testing.T) {
+	require := require.New(t)
+
+	// missing level
+	f := &LoggerFactory{Format: "text"}
+	_, err := f.New()
+	require.Error(err)
+
+	// invalid level
+	f = &LoggerFactory{Level: "text"}
+	_, err = f.New()
+	require.Error(err)
+
+	// missing format
+	f = &LoggerFactory{Level: "info"}
+	_, err = f.New()
+	require.Error(err)
+
+	// invalid format
+	f = &LoggerFactory{Level: "info", Format: "qux"}
+	_, err = f.New()
+	require.Error(err)
+
+	// invalid json
+	f = &LoggerFactory{Level: "info", Format: "text", Fields: "qux"}
+	_, err = f.New()
+	require.Error(err)
+}
+
+func TestLoggerFactoryApply(t *testing.T) {
+	require := require.New(t)
+
+	f := &LoggerFactory{Format: "text", Level: "debug"}
+	err := f.Apply()
+	require.NoError(err)
+
+	require.IsType(&prefixed.TextFormatter{}, logrus.StandardLogger().Formatter)
+	require.Equal(logrus.DebugLevel, logrus.StandardLogger().Level)
+}


### PR DESCRIPTION
Sometime is more convenient configure the default logger instead of use a custom instance. The new method `LoggerFactory.Apply` applies the factory settings to the default one.

This is really useful when third-party loggers are using logrus and the message are printed in a complete random style. (eg.: `libcontainer`)