### PR TITLE
uast: Make node ordering actually stable when there're no positions.

### DIFF
--- a/uast/node.go
+++ b/uast/node.go
@@ -509,7 +509,7 @@ func (s byOffset) Less(i, j int) bool {
 	}
 
 	if bpos == nil {
-		return true
+		return false
 	}
 
 	return apos.Offset < bpos.Offset


### PR DESCRIPTION
Signed-off-by: Alfredo Beaumont <alfredo.beaumont@gmail.com>

This should consider a node without a position as equal to any other, with or without a position, and thus make stable sort actually stable.