### PR TITLE
ToNoder.SpecificTokenKeys to specificy fields to use as Token for some nodes

### DIFF
--- a/uast/fixtures/java_example_1.json
+++ b/uast/fixtures/java_example_1.json
@@ -2702,6 +2702,7 @@
          }
       ],
       "internalClass" : "CompilationUnit",
+      "specificToken": "SomeSpecificToken",
       "package" : {
          "name" : {
             "qualifier" : {

--- a/uast/node_test.go
+++ b/uast/node_test.go
@@ -228,6 +228,25 @@ func TestPropertyListPromotionAll(t *testing.T) {
 	require.NotNil(child)
 }
 
+func TestSpecificTokens(t *testing.T) {
+	require := require.New(t)
+
+	f, err := getFixture("java_example_1.json")
+	require.NoError(err)
+
+	c := &ObjectToNode{
+		InternalTypeKey: "internalClass",
+		LineKey:         "line",
+		SpecificTokenKeys: map[string]string {
+			"CompilationUnit": "specificToken",
+		},
+	}
+	n, err := c.ToNode(f)
+	require.NoError(err)
+	require.NotNil(n)
+	require.True(n.Token == "SomeSpecificToken")
+}
+
 func TestSyntheticTokens(t *testing.T) {
 	require := require.New(t)
 
@@ -251,7 +270,6 @@ func TestSyntheticTokens(t *testing.T) {
 	require.NoError(err)
 	require.NotNil(n)
 	require.True(n.Token == "TestToken")
-
 }
 
 func findChildWithInternalType(n *Node, internalType string) *Node {


### PR DESCRIPTION
Fixes #170 

Signed-off-by: Juanjo Alvarez <juanjo@sourced.tech>