### PR TITLE
driver: fill the language when the Request.Language

### DIFF
--- a/sdk/driver/driver.go
+++ b/sdk/driver/driver.go
@@ -49,6 +49,11 @@ func (d *Driver) Parse(req *protocol.ParseRequest) *protocol.ParseResponse {
 
 	var ast interface{}
 	r.Response, ast = d.doParse(req.Language, req.Content, req.Encoding)
+
+	if r.Language == "" {
+		r.Language = d.m.Language
+	}
+
 	if r.Status == protocol.Fatal {
 		return r
 	}
@@ -83,6 +88,11 @@ func (d *Driver) NativeParse(req *protocol.NativeParseRequest) *protocol.NativeP
 
 	var ast interface{}
 	r.Response, ast = d.doParse(req.Language, req.Content, req.Encoding)
+
+	if r.Language == "" {
+		r.Language = d.m.Language
+	}
+
 	if r.Status == protocol.Fatal {
 		return r
 	}
@@ -99,7 +109,7 @@ func (d *Driver) NativeParse(req *protocol.NativeParseRequest) *protocol.NativeP
 func (d *Driver) doParse(language, content string, encoding protocol.Encoding) (
 	r protocol.Response, ast interface{},
 ) {
-	if !d.isValidateLanguage(language, &r) {
+	if !d.isValidLanguage(language, &r) {
 		return r, nil
 	}
 
@@ -115,7 +125,7 @@ func (d *Driver) doParse(language, content string, encoding protocol.Encoding) (
 	return
 }
 
-func (d *Driver) isValidateLanguage(language string, r *protocol.Response) bool {
+func (d *Driver) isValidLanguage(language string, r *protocol.Response) bool {
 	if language == d.m.Language {
 		return true
 	}

--- a/sdk/driver/driver_test.go
+++ b/sdk/driver/driver_test.go
@@ -32,6 +32,7 @@ func TestDriverParserParse(t *testing.T) {
 	require.NotNil(r)
 	require.Equal(len(r.Errors), 0)
 	require.Equal(r.Status, protocol.Ok)
+	require.Equal(r.Language, "fixture")
 	require.Equal(r.Elapsed.Nanoseconds() > 0, true)
 	require.Equal(r.UAST.String(), " "+
 		"{\n"+
@@ -115,6 +116,7 @@ func TestDriverParserNativeParse(t *testing.T) {
 	require.NotNil(r)
 	require.Equal(len(r.Errors), 0)
 	require.Equal(r.Status, protocol.Ok)
+	require.Equal(r.Language, "fixture")
 	require.Equal(r.Elapsed.Nanoseconds() > 0, true)
 	require.Equal(r.AST, "{\"root\":{\"key\":\"val\"}}")
 


### PR DESCRIPTION
(e. g. when running a driver directly).

Signed-off-by: Juanjo Alvarez <juanjo@sourced.tech>