### PR TITLE
Fix parsing ast with array

### DIFF
--- a/uast/node.go
+++ b/uast/node.go
@@ -383,6 +383,9 @@ func (c *ObjectToNode) sliceToNodeSlice(k string, s []interface{}) ([]*Node, err
 	var ns []*Node
 	for _, v := range s {
 		nodes, err := c.toNodes(v)
+		if ErrUnexpectedObject.Is(err) {
+			continue
+		}
 		if err != nil {
 			return nil, err
 		}

--- a/uast/node.go
+++ b/uast/node.go
@@ -294,6 +294,10 @@ func (c *ObjectToNode) toNodes(obj interface{}) ([]*Node, error) {
 
 			// This property -> List elements will be added as the current node Children
 			children, err := c.sliceToNodeSlice(k, ov)
+			// List of non-nodes
+			if ErrUnexpectedObject.Is(err) {
+				err = c.addProperty(n, k, ov)
+			}
 			if err != nil {
 				return nil, err
 			}
@@ -383,9 +387,6 @@ func (c *ObjectToNode) sliceToNodeSlice(k string, s []interface{}) ([]*Node, err
 	var ns []*Node
 	for _, v := range s {
 		nodes, err := c.toNodes(v)
-		if ErrUnexpectedObject.Is(err) {
-			continue
-		}
 		if err != nil {
 			return nil, err
 		}

--- a/uast/node_test.go
+++ b/uast/node_test.go
@@ -440,7 +440,8 @@ func TestToNodeWithArray(t *testing.T) {
 	require := require.New(t)
 
 	ast := map[string]interface{}{}
-	err := json.Unmarshal([]byte(`{"flags": ["a", "b"], "kind": "VariableDeclarationList"}`), &ast)
+	astJSON := `{"flags": ["a", "b"], "kind": "VariableDeclarationList"}`
+	err := json.Unmarshal([]byte(astJSON), &ast)
 	require.NoError(err)
 
 	c := &ObjectToNode{
@@ -451,6 +452,9 @@ func TestToNodeWithArray(t *testing.T) {
 	n, err := c.ToNode(ast)
 	require.NoError(err)
 	require.NotNil(n)
+	require.Equal(n.InternalType, "VariableDeclarationList")
+	require.Len(n.Properties, 1)
+	require.Equal(n.Properties["flags"], "[a b]")
 }
 
 func findChildWithInternalType(n *Node, internalType string) *Node {

--- a/uast/node_test.go
+++ b/uast/node_test.go
@@ -436,6 +436,23 @@ func TestOnToNode(t *testing.T) {
 	require.Len(n.Children, 18)
 }
 
+func TestToNodeWithArray(t *testing.T) {
+	require := require.New(t)
+
+	ast := map[string]interface{}{}
+	err := json.Unmarshal([]byte(`{"flags": ["a", "b"], "kind": "VariableDeclarationList"}`), &ast)
+	require.NoError(err)
+
+	c := &ObjectToNode{
+		TopLevelIsRootNode: true,
+		InternalTypeKey:    "kind",
+	}
+
+	n, err := c.ToNode(ast)
+	require.NoError(err)
+	require.NotNil(n)
+}
+
 func findChildWithInternalType(n *Node, internalType string) *Node {
 	for _, child := range n.Children {
 		if child.InternalType == internalType {


### PR DESCRIPTION
Example of real AST (typescript):

```
      {
        "col": 1,
        "declarationList": {
          "col": 1,
          "declarations": [...],
          "end": 19,
          "flags": ["Const", "BlockScoped"],
          "kind": "VariableDeclarationList",
          "line": 1,
          "pos": 0
        },
        "end": 20,
        "flags": [],
        "kind": "VariableStatement",
        "line": 1,
        "modifierFlagsCache": 536870912,
        "pos": 0
      }
```

Now driver always return:
```
expected object of type map[string]interface{}, got: "Const"
	Writing fixtures/simple.ts.uast ...
```

Please, guide me how to fix it if current solution is wrong.

Thanks!