### PR TITLE
[Node.go] Export nil property values in the native AST as json null

### DIFF
--- a/uast/node.go
+++ b/uast/node.go
@@ -618,6 +618,10 @@ func startPosition(n *Node) *Position {
 }
 
 func toPropValue(o interface{}) (string, error) {
+	if o == nil {
+		return "null", nil
+	}
+
 	t := reflect.TypeOf(o)
 	switch t.Kind() {
 	case reflect.Map, reflect.Slice, reflect.Array:

--- a/uast/node_test.go
+++ b/uast/node_test.go
@@ -482,6 +482,25 @@ func TestToNodePropsMap(t *testing.T) {
 	require.Equal(`{"value":true}`, n.Properties["map"])
 }
 
+func TestToNodePropsNil(t *testing.T) {
+	require := require.New(t)
+
+	ast := map[string]interface{}{}
+	astJSON := `{"somenull": null}`
+	err := json.Unmarshal([]byte(astJSON), &ast)
+	require.NoError(err)
+
+	c := &ObjectToNode{
+		TopLevelIsRootNode: true,
+	}
+
+	n, err := c.ToNode(ast)
+	require.NoError(err)
+	require.NotNil(n)
+	require.Len(n.Properties, 1)
+	require.Equal(`null`, n.Properties["somenull"])
+}
+
 func findChildWithInternalType(n *Node, internalType string) *Node {
 	for _, child := range n.Children {
 		if child.InternalType == internalType {


### PR DESCRIPTION
Avoid a crash when converting null values in the native AST.

Signed-off-by: Juanjo Alvarez <juanjo@sourced.tech>