### PR TITLE
sdk: replace ADD with wget to avoid requiring internet to build

### DIFF
--- a/assets/build/bindata.go
+++ b/assets/build/bindata.go
@@ -105,7 +105,8 @@ ENV GOLANG_SRC_URL https://golang.org/dl/go${RUNTIME_GO_VERSION}.src.tar.gz
 
 # from https://github.com/docker-library/golang/blob/master/1.8/alpine/Dockerfile
 
-ADD https://raw.githubusercontent.com/docker-library/golang/132cd70768e3bc269902e4c7b579203f66dc9f64/1.8/alpine/no-pic.patch /
+RUN apk add --update --no-cache ca-certificates openssl && update-ca-certificates
+RUN wget https://raw.githubusercontent.com/docker-library/golang/132cd70768e3bc269902e4c7b579203f66dc9f64/1.8/alpine/no-pic.patch
 
 RUN set -ex \
 	&& apk add --no-cache --virtual .build-deps \
@@ -142,7 +143,7 @@ func etcBuildDockerfileBuildAlpineTpl() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "etc/build/Dockerfile.build.alpine.tpl", size: 858, mode: os.FileMode(420), modTime: time.Unix(1, 0)}
+	info := bindataFileInfo{name: "etc/build/Dockerfile.build.alpine.tpl", size: 943, mode: os.FileMode(420), modTime: time.Unix(1, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }

--- a/etc/build/etc/build/Dockerfile.build.alpine.tpl
+++ b/etc/build/etc/build/Dockerfile.build.alpine.tpl
@@ -4,7 +4,8 @@ ENV GOLANG_SRC_URL https://golang.org/dl/go${RUNTIME_GO_VERSION}.src.tar.gz
 
 # from https://github.com/docker-library/golang/blob/master/1.8/alpine/Dockerfile
 
-ADD https://raw.githubusercontent.com/docker-library/golang/132cd70768e3bc269902e4c7b579203f66dc9f64/1.8/alpine/no-pic.patch /
+RUN apk add --update --no-cache ca-certificates openssl && update-ca-certificates
+RUN wget https://raw.githubusercontent.com/docker-library/golang/132cd70768e3bc269902e4c7b579203f66dc9f64/1.8/alpine/no-pic.patch
 
 RUN set -ex \
 	&& apk add --no-cache --virtual .build-deps \


### PR DESCRIPTION
`ADD` invalidates build cache ([more info](https://docs.docker.com/engine/userguide/eng-image/dockerfile_best-practices/#add-or-copy))
So currently it's impossible to build any of the drivers without having access to the internet

This will make it so I can easily build my drivers from a coffee place without WiFi