### PR TITLE
On 1-indexed empty files the max column checked is 1

### DIFF
--- a/uast/transformer/positioner/positions.go
+++ b/uast/transformer/positioner/positions.go
@@ -145,7 +145,13 @@ func (idx *positionIndex) Offset(line, col int) (int, error) {
 	}
 
 	maxCol := maxOffset - idx.offsetByLine[line] + 1
-	if col < minCol || col > maxCol {
+
+	// For empty files with 1-indexed drivers, set maxCol to 1
+	if (maxCol == 0 && col == 1) {
+		maxCol = 1
+	}
+
+	if col < minCol || (maxCol > 0 && col > maxCol) {
 		return 0, fmt.Errorf("column out of bounds: %d [%d, %d]", col, minCol, maxCol)
 	}
 

--- a/uast/transformer/positioner/positions_test.go
+++ b/uast/transformer/positioner/positions_test.go
@@ -63,3 +63,24 @@ func TestFillOffsetFromLineCol(t *testing.T) {
 	require.NoError(err)
 	require.Equal(expected, input)
 }
+
+func TestEmptyFile(t *testing.T) {
+	require := require.New(t)
+
+	data := ""
+
+	input := &uast.Node{
+		StartPosition: &uast.Position{Line: 1, Col: 1},
+		EndPosition:   &uast.Position{Line: 1, Col: 1},
+	}
+
+	expected := &uast.Node{
+		StartPosition: &uast.Position{Offset: 0, Line: 1, Col: 1},
+		EndPosition:   &uast.Position{Offset: 0, Line: 1, Col: 1},
+	}
+
+	p := NewFillOffsetFromLineCol()
+	err := p.Do(data, 0, input)
+	require.NoError(err)
+	require.Equal(expected, input)
+}


### PR DESCRIPTION
Fixes #160 

Signed-off-by: Juanjo Alvarez <juanjo@sourced.tech>