### PR TITLE
Move driver discovery from docs repository to SDK

### DIFF
--- a/manifest/discovery/discovery.go
+++ b/manifest/discovery/discovery.go
@@ -1,0 +1,289 @@
+// discovery package implements helpers for clients to discover language drivers supported by Babelfish.
+package discovery
+
+import (
+	"bufio"
+	"context"
+	"fmt"
+	"net/http"
+	"regexp"
+	"sort"
+	"strings"
+	"sync"
+
+	"github.com/google/go-github/github"
+	"gopkg.in/bblfsh/sdk.v1/manifest"
+)
+
+const (
+	GithubOrg = "bblfsh"
+)
+
+// topics that each driver repository on Github should be annotated with
+var topics = []string{
+	"babelfish", "driver",
+}
+
+// Driver is an object describing language driver and it's repository-related information.
+type Driver struct {
+	manifest.Manifest
+	repo        *github.Repository
+	Maintainers []Maintainer `json:",omitempty"`
+}
+
+type byStatusAndName []Driver
+
+func (arr byStatusAndName) Len() int {
+	return len(arr)
+}
+
+func (arr byStatusAndName) Less(i, j int) bool {
+	a, b := arr[i], arr[j]
+	// sort by status, features count, name
+	if s1, s2 := a.Status.Rank(), b.Status.Rank(); s1 > s2 {
+		return true
+	} else if s1 < s2 {
+		return false
+	}
+	if n1, n2 := len(a.Features), len(b.Features); n1 > n2 {
+		return true
+	} else if n1 < n2 {
+		return false
+	}
+	return a.Language < b.Language
+}
+
+func (arr byStatusAndName) Swap(i, j int) {
+	arr[i], arr[j] = arr[j], arr[i]
+}
+
+// Maintainer is an information about project maintainer.
+type Maintainer struct {
+	Name   string `json:",omitempty"`
+	Email  string `json:",omitempty"`
+	Github string `json:",omitempty"` // github handle
+}
+
+// GithubURL returns github profile URL.
+func (m Maintainer) GithubURL() string {
+	if m.Github != "" {
+		return `https://github.com/` + m.Github
+	}
+	return ""
+}
+
+// URL returns a contact of the maintainer (either Github profile or email link).
+func (m Maintainer) URL() string {
+	if m.Github != "" {
+		return m.GithubURL()
+	} else if m.Email != "" {
+		return `mailto:` + m.Email
+	}
+	return ""
+}
+
+// InDevelopment indicates that driver is incomplete and should only be used for development purposes.
+func (d Driver) InDevelopment() bool {
+	return d.Status.Rank() < manifest.Alpha.Rank()
+}
+
+// IsRecommended indicates that driver is stable enough to be used in production.
+func (d Driver) IsRecommended() bool {
+	return d.Status.Rank() >= manifest.Beta.Rank()
+}
+
+// RepositoryURL returns Github repository URL for browsers (not git).
+func (d Driver) RepositoryURL() string {
+	return d.repo.GetHTMLURL()
+}
+
+// repositoryFileURL returns an URL of file in the driver's repository.
+func (d Driver) repositoryFileURL(path string) string {
+	path = strings.TrimPrefix(path, "/")
+	return fmt.Sprintf("https://raw.githubusercontent.com/%s/master/%s", d.repo.GetFullName(), path)
+}
+
+// newReq constructs a GET request with context.
+func newReq(ctx context.Context, url string) *http.Request {
+	req, err := http.NewRequest("GET", url, nil)
+	if err != nil {
+		// if it fails, it's a programmer's error
+		panic(err)
+	}
+	return req.WithContext(ctx)
+}
+
+// loadManifest reads manifest file from repository and decodes it into object.
+func (d *Driver) loadManifest(ctx context.Context) error {
+	req := newReq(ctx, d.repositoryFileURL(manifest.Filename))
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode == http.StatusNotFound {
+		// outdated driver
+		d.Name = d.Language
+		d.Status = manifest.Inactive
+		return nil
+	} else if resp.StatusCode/100 != 2 { // 2xx
+		return fmt.Errorf("status: %v", resp.Status)
+	}
+
+	lang := d.Language
+	if err := d.Manifest.Decode(resp.Body); err != nil {
+		return err
+	}
+	// override language ID from manifest (prevents copy-paste of manifests)
+	d.Language = lang
+	if d.Name == "" {
+		d.Name = d.Language
+	}
+	return nil
+}
+
+// reMaintainer is a regexp for one line of MAINTAINERS file (Github handle is optional):
+//
+//		John Doe <john@domain.com> (@john_at_github)
+var reMaintainer = regexp.MustCompile(`^([^<(]+)\s<([^>]+)>(\s\(@([^\s]+)\))?`)
+
+// loadMaintainers reads MAINTAINERS file from repository and decodes it into object.
+//
+// Each line in a file should follow the format defined by reMaintainer regexp.
+func (d *Driver) loadMaintainers(ctx context.Context) error {
+	req := newReq(ctx, d.repositoryFileURL("MAINTAINERS"))
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode == http.StatusNotFound {
+		return nil
+	} else if resp.StatusCode/100 != 2 {
+		return fmt.Errorf("status: %v", resp.Status)
+	}
+
+	var out []Maintainer
+	sc := bufio.NewScanner(resp.Body)
+	for sc.Scan() {
+		line := strings.TrimSpace(sc.Text())
+		sub := reMaintainer.FindStringSubmatch(line)
+		if len(sub) == 0 {
+			continue
+		}
+		m := Maintainer{Name: sub[1], Email: sub[2]}
+		if len(sub) >= 5 {
+			m.Github = sub[4]
+		}
+		out = append(out, m)
+	}
+	d.Maintainers = out
+	return nil
+}
+
+type Options struct {
+	Organization  string // Github organization name
+	NamesOnly     bool   // driver manifest will only have Language field populated
+	NoMaintainers bool   // do not load maintainers list
+}
+
+// OfficialDrivers lists all available language drivers for Babelfish.
+func OfficialDrivers(ctx context.Context, opt *Options) ([]Driver, error) {
+	if opt == nil {
+		opt = &Options{}
+	}
+	if opt.Organization == "" {
+		opt.Organization = GithubOrg
+	}
+	cli := github.NewClient(nil)
+
+	var out []Driver
+	// list all repositories in organization
+	for page := 1; ; page++ {
+		repos, _, err := cli.Repositories.ListByOrg(ctx, opt.Organization, &github.RepositoryListByOrgOptions{
+			ListOptions: github.ListOptions{
+				Page: page, PerPage: 100,
+			},
+			Type: "public",
+		})
+		if err != nil {
+			return out, err
+		} else if len(repos) == 0 {
+			break
+		}
+		for _, r := range repos {
+			// filter repos by topics to find babelfish drivers
+			if containsTopics(r.Topics, topics...) {
+				out = append(out, Driver{
+					Manifest: manifest.Manifest{
+						Language: strings.TrimSuffix(r.GetName(), "-driver"),
+					},
+					repo: r,
+				})
+			}
+		}
+	}
+	if opt.NamesOnly {
+		sort.Sort(byStatusAndName(out))
+		return out, nil
+	}
+
+	// load manifest and maintainers file from repositories
+	var (
+		wg sync.WaitGroup
+		// limits the number of concurrent requests
+		tokens = make(chan struct{}, 3)
+
+		mu   sync.Mutex
+		last error
+	)
+
+	setErr := func(err error) {
+		mu.Lock()
+		last = err
+		mu.Unlock()
+	}
+	for i := range out {
+		wg.Add(1)
+		go func(d *Driver) {
+			defer wg.Done()
+
+			tokens <- struct{}{}
+			defer func() {
+				<-tokens
+			}()
+			if err := d.loadManifest(ctx); err != nil {
+				setErr(err)
+			}
+			if !opt.NoMaintainers {
+				if err := d.loadMaintainers(ctx); err != nil {
+					setErr(err)
+				}
+			}
+		}(&out[i])
+	}
+	wg.Wait()
+	sort.Sort(byStatusAndName(out))
+	return out, last
+}
+
+// containsTopics returns true if all inc topics are present in the list.
+func containsTopics(topics []string, inc ...string) bool {
+	n := 0
+	for _, t := range topics {
+		ok := false
+		for _, t2 := range inc {
+			if t == t2 {
+				ok = true
+				break
+			}
+		}
+		if ok {
+			n++
+		}
+	}
+	return n == len(inc)
+}

--- a/manifest/discovery/discovery_test.go
+++ b/manifest/discovery/discovery_test.go
@@ -1,0 +1,47 @@
+package discovery
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"gopkg.in/bblfsh/sdk.v1/manifest"
+)
+
+func TestParseMaintainers(t *testing.T) {
+	m := parseMaintainers(strings.NewReader(`
+John Doe <john@domain.com> (@john_at_github)
+Bob <bob@domain.com>
+`))
+	require.Equal(t, []Maintainer{
+		{Name: "John Doe", Email: "john@domain.com", Github: "john_at_github"},
+		{Name: "Bob", Email: "bob@domain.com"},
+	}, m)
+}
+
+func TestOfficialDrivers(t *testing.T) {
+	if testing.Short() {
+		t.SkipNow()
+	}
+	drivers, err := OfficialDrivers(context.Background(), nil)
+	require.NoError(t, err)
+	require.True(t, len(drivers) >= 15, "drivers: %d", len(drivers))
+
+	// make sure that IDs are distinct
+	m := make(map[string]Driver)
+	for _, d := range drivers {
+		m[d.Language] = d
+	}
+
+	for _, exp := range []Driver{
+		{Manifest: manifest.Manifest{Language: "go", Name: "Go"}},
+		{Manifest: manifest.Manifest{Language: "javascript", Name: "JavaScript"}},
+	} {
+		got := m[exp.Language]
+		require.Equal(t, exp.Language, got.Language)
+		require.Equal(t, exp.Name, got.Name)
+		require.NotEmpty(t, got.Maintainers)
+		require.NotEmpty(t, got.Features)
+	}
+}

--- a/manifest/manifest.go
+++ b/manifest/manifest.go
@@ -23,6 +23,22 @@ const (
 	Inactive DevelopmentStatus = "inactive"
 )
 
+// Rank is an integer indicating driver stability. Higher is better.
+func (s DevelopmentStatus) Rank() int {
+	// TODO: make DevelopmentStatus an int enum and provide text marshal/unmarshal methods
+	return statusRanks[s]
+}
+
+var statusRanks = map[DevelopmentStatus]int{
+	Inactive: 0,
+	Planning: 1,
+	PreAlpha: 2,
+	Alpha:    3,
+	Beta:     4,
+	Stable:   5,
+	Mature:   6,
+}
+
 // InformationLoss in terms of which kind of code generation would they allow.
 type InformationLoss string
 
@@ -90,6 +106,16 @@ type Manifest struct {
 		GoVersion     string   `toml:"go_version"`
 	} `toml:"runtime"`
 	Features []Feature `toml:"features"`
+}
+
+// Supports checks if driver supports specified feature.
+func (m Manifest) Supports(f Feature) bool {
+	for _, f2 := range m.Features {
+		if f == f2 {
+			return true
+		}
+	}
+	return false
 }
 
 type Versions []string


### PR DESCRIPTION
Driver discovery uses public Github API to list all supported drivers and their manifests.

This functionality will be used by [language table generator](https://github.com/bblfsh/documentation/pull/141) for docs repository and [bblfshd](https://github.com/bblfsh/bblfshd/pull/148) to get the list of official/recommended drivers.  

Signed-off-by: Denys Smirnov <denys@sourced.tech>