### PR TITLE
Don't consider untracked files for marking a build as dirty

### DIFF
--- a/assets/build/bindata.go
+++ b/assets/build/bindata.go
@@ -228,7 +228,7 @@ RUNTIME_GO_VERSION ?=
 
 # get the git commit
 GIT_COMMIT=$(shell git rev-parse HEAD | cut -c1-7)
-GIT_DIRTY=$(shell test -n "` + "`" + `git status --porcelain` + "`" + `" && echo "-dirty" || true)
+GIT_DIRTY=$(shell test -n "` + "`" + `git status --porcelain -uno` + "`" + `" && echo "-dirty" || true)
 
 # optional variables
 DRIVER_DEV_PREFIX := dev
@@ -273,7 +273,7 @@ func makeBootstrapMk() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "make/bootstrap.mk", size: 1260, mode: os.FileMode(420), modTime: time.Unix(1, 0)}
+	info := bindataFileInfo{name: "make/bootstrap.mk", size: 1265, mode: os.FileMode(420), modTime: time.Unix(1, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }

--- a/etc/build/make/bootstrap.mk
+++ b/etc/build/make/bootstrap.mk
@@ -6,7 +6,7 @@ RUNTIME_GO_VERSION ?=
 
 # get the git commit
 GIT_COMMIT=$(shell git rev-parse HEAD | cut -c1-7)
-GIT_DIRTY=$(shell test -n "`git status --porcelain`" && echo "-dirty" || true)
+GIT_DIRTY=$(shell test -n "`git status --porcelain -uno`" && echo "-dirty" || true)
 
 # optional variables
 DRIVER_DEV_PREFIX := dev


### PR DESCRIPTION
(this is for ~v2 since ~master is probably best left for critical fixes until we merge both branches to avoid complicating that final merge too much).

Don't consider git-untracked files to mark a docker build (or not) as dirty. This mainly avoids having caches and temporals generated by the build system or languages marking the images as dirty, which has given non-obvious problems more than once with CI of some drivers that naturally generate temporal files (like Python's `__pycache__`, `.mypy` and other files/directories).

Signed-off-by: Juanjo Alvarez <juanjo@sourced.tech>