### PR TITLE
Allow to dump a preprocessed UAST in fixture tests

### DIFF
--- a/sdk/driver/driver.go
+++ b/sdk/driver/driver.go
@@ -14,7 +14,8 @@ import (
 type Mode int
 
 const (
-	ModeAnnotated = Mode(iota)
+	ModePreprocessed = Mode(iota)
+	ModeAnnotated
 	ModeSemantic
 )
 
@@ -52,6 +53,9 @@ func (t Transforms) Do(mode Mode, code string, nd nodes.Node) (nodes.Node, error
 	}
 	if err := runAll(t.Preprocess); err != nil {
 		return nd, err
+	}
+	if mode <= ModePreprocessed {
+		return nd, nil
 	}
 	if mode >= ModeSemantic {
 		if err := runAll(t.Normalize); err != nil {

--- a/sdk/driver/fixtures/fixtures.go
+++ b/sdk/driver/fixtures/fixtures.go
@@ -38,9 +38,10 @@ type Suite struct {
 	// Update* and Write* flags below should never be committed in "true" state.
 	// They serve only as helpers for debugging.
 
-	UpdateNative    bool // update native ASTs in fixtures to ones produced by driver
-	UpdateUAST      bool // update UASTs in fixtures to ones produced by driver
-	WriteViewerJSON bool // write JSON compatible with uast-viewer
+	UpdateNative      bool // update native ASTs in fixtures to ones produced by driver
+	UpdateUAST        bool // update UASTs in fixtures to ones produced by driver
+	WriteViewerJSON   bool // write JSON compatible with uast-viewer
+	WritePreprocessed bool // write a preprocessed UAST for fixtures
 
 	NewDriver  func() driver.BaseDriver
 	Transforms driver.Transforms
@@ -99,6 +100,7 @@ func (s *Suite) RunBenchmarks(t *testing.B) {
 const (
 	gotSuffix = "_got"
 	nativeExt = ".native"
+	preExt    = ".pre.uast"
 	uastExt   = ".uast"
 	highExt   = ".sem.uast"
 )
@@ -200,6 +202,15 @@ func (s *Suite) testFixturesUAST(t *testing.T, mode driver.Mode, suf string, bla
 			require.NoError(t, err)
 
 			tr := s.Transforms
+			if s.WritePreprocessed {
+				ua, err := tr.Do(driver.ModePreprocessed, code, ast)
+				require.NoError(t, err)
+
+				un, err := marshalUAST(ua)
+				require.NoError(t, err)
+
+				s.writeFixturesFile(t, name+preExt, string(un))
+			}
 			ua, err := tr.Do(mode, code, ast)
 			require.NoError(t, err)
 


### PR DESCRIPTION
Signed-off-by: Denys Smirnov <denys@sourced.tech>