### PR TITLE
Optimize UAST transforms

### DIFF
--- a/sdk/driver/fixtures/fixtures.go
+++ b/sdk/driver/fixtures/fixtures.go
@@ -352,7 +352,7 @@ func (s *Suite) benchmarkTransform(b *testing.B) {
 	for i := 0; i < b.N; i++ {
 		ast := rast.Clone()
 
-		ua, err := tr.Do(driver.ModeAnnotated, code, ast)
+		ua, err := tr.Do(driver.ModeSemantic, code, ast)
 		if err != nil {
 			b.Fatal(err)
 		}

--- a/sdk/driver/fixtures/fixtures.go
+++ b/sdk/driver/fixtures/fixtures.go
@@ -96,8 +96,13 @@ func (s *Suite) RunTests(t *testing.T) {
 	})
 }
 
-func (s *Suite) RunBenchmarks(t *testing.B) {
-	t.Run("transform", s.benchmarkTransform)
+func (s *Suite) RunBenchmarks(b *testing.B) {
+	b.Run("transform", func(b *testing.B) {
+		s.benchmarkTransform(b, false)
+	})
+	b.Run("transform-legacy", func(b *testing.B) {
+		s.benchmarkTransform(b, true)
+	})
 }
 
 const (
@@ -318,7 +323,7 @@ func (s *Suite) testFixturesUAST(t *testing.T, mode driver.Mode, suf string, bla
 	}
 }
 
-func (s *Suite) benchmarkTransform(b *testing.B) {
+func (s *Suite) benchmarkTransform(b *testing.B, legacy bool) {
 	if s.BenchName == "" {
 		b.SkipNow()
 	}
@@ -357,10 +362,12 @@ func (s *Suite) benchmarkTransform(b *testing.B) {
 			b.Fatal(err)
 		}
 
-		un, err := protocol.ToNode(ua)
-		if err != nil {
-			b.Fatal(err)
+		if legacy {
+			un, err := protocol.ToNode(ua)
+			if err != nil {
+				b.Fatal(err)
+			}
+			_ = un
 		}
-		_ = un
 	}
 }

--- a/uast/transformer/ops.go
+++ b/uast/transformer/ops.go
@@ -264,11 +264,14 @@ func (o Obj) ConstructObj(st *State, n nodes.Object) (nodes.Object, error) {
 
 type FieldDesc struct {
 	Optional bool        // field might not exists in the object
-	Fixed    *nodes.Node // field is require to have a fixed value
+	Fixed    *nodes.Node // field is required to have a fixed value; the value may be nil
 }
 
+// FieldDescs is a descriptions of static fields of an object.
+// Transformation operation may return this struct to indicate what fields they will require.
 type FieldDescs map[string]FieldDesc
 
+// Clone makes a copy of field description, without cloning each field values.
 func (f FieldDescs) Clone() FieldDescs {
 	if f == nil {
 		return nil
@@ -279,6 +282,9 @@ func (f FieldDescs) Clone() FieldDescs {
 	}
 	return fields
 }
+
+// CheckObj verifies that an object matches field descriptions.
+// It ignores all fields in the object that are not described.
 func (f FieldDescs) CheckObj(n nodes.Object) bool {
 	for k, d := range f {
 		if d.Optional {

--- a/uast/transformer/transformer.go
+++ b/uast/transformer/transformer.go
@@ -255,7 +255,7 @@ func (m *mappings) index() {
 		mp = precompile(mp)
 
 		oop, _ := mp.Mapping()
-		if chk, ok := oop.(opCheck); ok {
+		if chk, ok := oop.(*opCheck); ok {
 			oop = chk.op
 		}
 		// switch by operation type and make a separate list


### PR DESCRIPTION
Address performance issues in the last SDK version.

In short: large transforms are an order of magnitude faster now. 

```
benchmark                         old ns/op      new ns/op     delta
BenchmarkGoDriver/transform-4     3181055629     261985232     -91.76%

benchmark                         old allocs     new allocs     delta
BenchmarkGoDriver/transform-4     18913347       561193         -97.03%

benchmark                         old bytes      new bytes     delta
BenchmarkGoDriver/transform-4     2509354920     54671790      -97.82%
```