### PR TITLE
ast2gv: allow to omit position info and nil fields

### DIFF
--- a/cmd/bblfsh-sdk-tools/cmd/ast2gv.go
+++ b/cmd/bblfsh-sdk-tools/cmd/ast2gv.go
@@ -25,6 +25,8 @@ type Ast2GraphvizCommand struct {
 	Output   string `long:"out" short:"o" default:"dot" description:"Output format (dot, svg, png)"`
 	TypePred string `long:"type" short:"t" default:"@type" description:"Node type field in native AST"`
 	Colors   string `long:"colors" short:"c" default:"colors.yml" description:"File with node color definitions"`
+	NoPos    bool   `long:"no-pos" description:"Omit position info"`
+	NoNils   bool   `long:"no-nils" description:"Omit nil fields"`
 
 	nodeColors map[string]string
 }
@@ -163,10 +165,16 @@ func (c *Ast2GraphvizCommand) writeGraphviz(w io.Writer, n nodes.Node) error {
 			n = n.CloneObject()
 			tp, _ := n[c.TypePred].(nodes.String)
 			delete(n, c.TypePred)
+			if c.NoPos {
+				delete(n, "@pos")
+			}
 			writeNode(id, string(tp), circle, c.nodeColors[string(tp)], tp == "")
 			keys := n.Keys()
 			for _, k := range keys {
 				v := n[k]
+				if c.NoNils && v == nil {
+					continue
+				}
 				sid := proc(v)
 				writePred(id, k, sid)
 			}


### PR DESCRIPTION
AST2GV is a tool that converts a YML AST file to Graphviz/SVG/PNG image.

This PR adds two new CLI options:
* omit positional nodes,
* omit empty fields.

Currently, an AST might look a bit overloaded with information:

![image](https://user-images.githubusercontent.com/676724/43586308-f70a897a-966f-11e8-9b7d-9c6f91261d25.png)

With both options enabled the result is much more readable:

![image](https://user-images.githubusercontent.com/676724/43586391-331e1648-9670-11e8-98f1-75d923d588df.png)

Signed-off-by: Denys Smirnov <denys@sourced.tech>