### PR TITLE
Increase checked max line column by 1

### DIFF
--- a/uast/transformer/positioner/positions.go
+++ b/uast/transformer/positioner/positions.go
@@ -146,7 +146,7 @@ func (idx *positionIndex) Offset(line, col int) (int, error) {
 		maxCol = 1
 	}
 
-	if col < minCol || (maxCol > 0 && col > maxCol) {
+	if col < minCol || (maxCol > 0 && col - 1 > maxCol) {
 		return 0, fmt.Errorf("column out of bounds: %d [%d, %d]", col, minCol, maxCol)
 	}
 


### PR DESCRIPTION
Drivers use (and the dashboard expect) a closed-open interval, so a len 4 identifier starting from 1 would have start,end columns (1,5).

This changes the check in the SDK that checks that the end column doesn't exceed the line length, because without the change an identifier that would end in a line without a newline (ie the last identifier of a file not finished with an endline) would trigger an error.

Fixes bblfsh/python-driver/issues/164.

Signed-off-by: Juanjo Alvarez <juanjo@sourced.tech>