### PR TITLE
Accept external node implementations

### DIFF
--- a/uast/nodes/external.go
+++ b/uast/nodes/external.go
@@ -1,0 +1,143 @@
+package nodes
+
+import (
+	"fmt"
+)
+
+// External is a node interface that can be implemented by other packages.
+type External interface {
+	// Kind returns a node kind.
+	Kind() Kind
+	// Value returns a primitive value of the node or nil if node is not a value.
+	Value() Value
+}
+
+// ExternalArray is an analog of Array type.
+type ExternalArray interface {
+	External
+	// Size returns the number of child nodes.
+	Size() int
+	// ValueAt returns a array value by an index.
+	ValueAt(i int) External
+}
+
+// ExternalObject is an analog of Object type.
+type ExternalObject interface {
+	External
+	// Size returns the number of fields in an object.
+	Size() int
+	// Keys returns a sorted list of keys (object field names).
+	Keys() []string
+	// ValueAt returns an object field by key. It returns false if key does not exist.
+	ValueAt(key string) (External, bool)
+}
+
+// toNodeExt converts the external node to a native node type.
+// The returned value is the copy of an original node.
+func toNodeExt(n External) (Node, error) {
+	if n == nil {
+		return nil, nil
+	}
+	switch kind := n.Kind(); kind {
+	case KindNil:
+		return nil, nil
+	case KindObject:
+		o, ok := n.(ExternalObject)
+		if !ok {
+			return nil, fmt.Errorf("node type %T returns a %v kind, but doesn't implement the interface", n, kind)
+		}
+		keys := o.Keys()
+		m := make(Object, len(keys))
+		for _, k := range keys {
+			nv, ok := o.ValueAt(k)
+			if !ok {
+				return nil, fmt.Errorf("node type %T: key %q is listed, but cannot be fetched", n, k)
+			}
+			v, err := toNodeExt(nv)
+			if err != nil {
+				return nil, err
+			}
+			m[k] = v
+		}
+		return m, nil
+	case KindArray:
+		a, ok := n.(ExternalArray)
+		if !ok {
+			return nil, fmt.Errorf("node type %T returns a %v kind, but doesn't implement the interface", n, kind)
+		}
+		sz := a.Size()
+		m := make(Array, sz)
+		for i := 0; i < sz; i++ {
+			nv := a.ValueAt(i)
+			v, err := toNodeExt(nv)
+			if err != nil {
+				return nil, err
+			}
+			m[i] = v
+		}
+		return m, nil
+	default:
+		return n.Value(), nil
+	}
+}
+
+// equalExt compares two external nodes.
+func equalExt(n1, n2 External) bool {
+	k1, k2 := n1.Kind(), n2.Kind()
+	if k1 != k2 {
+		return false
+	}
+	switch k1 {
+	case KindObject:
+		o1, ok := n1.(ExternalObject)
+		if !ok {
+			return false
+		}
+		o2, ok := n2.(ExternalObject)
+		if !ok {
+			return false
+		}
+		if o1.Size() != o2.Size() {
+			return false
+		}
+		keys1, keys2 := o1.Keys(), o2.Keys()
+		m := make(map[string]struct{}, len(keys1))
+		for _, k := range keys1 {
+			m[k] = struct{}{}
+		}
+		for _, k := range keys2 {
+			if _, ok := m[k]; ok {
+				return false
+			}
+			v1, _ := o1.ValueAt(k)
+			v2, _ := o2.ValueAt(k)
+			if !Equal(v1, v2) {
+				return false
+			}
+		}
+		return true
+	case KindArray:
+		a1, ok := n1.(ExternalArray)
+		if !ok {
+			return false
+		}
+		a2, ok := n2.(ExternalArray)
+		if !ok {
+			return false
+		}
+		sz := a1.Size()
+		if sz != a2.Size() {
+			return false
+		}
+		for i := 0; i < sz; i++ {
+			v1 := a1.ValueAt(i)
+			v2 := a2.ValueAt(i)
+			if !Equal(v1, v2) {
+				return false
+			}
+		}
+		return true
+	default:
+		return n1.Value() == n2.Value()
+	}
+}

--- a/uast/nodes/external.go
+++ b/uast/nodes/external.go
@@ -84,11 +84,11 @@ func toNodeExt(n External) (Node, error) {
 // equalExt compares two external nodes.
 func equalExt(n1, n2 External) bool {
 	k1, k2 := n1.Kind(), n2.Kind()
-	if k1 != k2 {
-		return false
-	}
 	switch k1 {
 	case KindObject:
+		if k2 != KindObject {
+			return false
+		}
 		o1, ok := n1.(ExternalObject)
 		if !ok {
 			return false
@@ -106,7 +106,7 @@ func equalExt(n1, n2 External) bool {
 			m[k] = struct{}{}
 		}
 		for _, k := range keys2 {
-			if _, ok := m[k]; ok {
+			if _, ok := m[k]; !ok {
 				return false
 			}
 			v1, _ := o1.ValueAt(k)
@@ -117,6 +117,9 @@ func equalExt(n1, n2 External) bool {
 		}
 		return true
 	case KindArray:
+		if k2 != KindArray {
+			return false
+		}
 		a1, ok := n1.(ExternalArray)
 		if !ok {
 			return false
@@ -138,6 +141,6 @@ func equalExt(n1, n2 External) bool {
 		}
 		return true
 	default:
-		return n1.Value() == n2.Value()
+		return Equal(n1.Value(), n2.Value())
 	}
 }

--- a/uast/nodes/node.go
+++ b/uast/nodes/node.go
@@ -9,13 +9,19 @@ import (
 const applySort = false
 
 // Equal compares two subtrees.
-func Equal(n1, n2 Node) bool {
+// Equality is checked by value (deep), not by reference.
+func Equal(n1, n2 External) bool {
 	if n1 == nil && n2 == nil {
 		return true
-	} else if n1 != nil && n2 != nil {
-		return n1.Equal(n2)
+	} else if n1 == nil || n2 == nil {
+		return false
 	}
-	return false
+	if n, ok := n1.(Node); ok {
+		return n.Equal(n2)
+	} else if n, ok = n2.(Node); ok {
+		return n.Equal(n1)
+	}
+	return equalExt(n1, n2)
 }
 
 // Node is a generic interface for a tree structure.
@@ -25,15 +31,19 @@ func Equal(n1, n2 Node) bool {
 //	* Array
 //	* Value
 type Node interface {
+	External
 	// Clone creates a deep copy of the node.
 	Clone() Node
+	// Native returns a native Go type for this node.
 	Native() interface{}
-	Equal(n2 Node) bool
-	isNode() // to limit possible types
-	kind() Kind
+	// Equal checks if the node is equal to another node.
+	// Equality is checked by value (deep), not by reference.
+	Equal(n2 External) bool
+
+	isNode() // to limit possible implementations
 }
 
-// Value is a generic interface for values stored inside the tree.
+// Value is a generic interface for primitive values.
 //
 // Can be one of:
 //	* String
@@ -127,20 +137,30 @@ const (
 )
 
 // KindOf returns a kind of the node.
-func KindOf(n Node) Kind {
+func KindOf(n External) Kind {
 	if n == nil {
 		return KindNil
 	}
-	return n.kind()
+	return n.Kind()
 }
+
+var _ ExternalObject = Object{}
 
 // Object is a representation of generic node with fields.
 type Object map[string]Node
 
 func (Object) isNode() {}
 
-func (Object) kind() Kind {
+func (Object) Kind() Kind {
 	return KindObject
+}
+
+func (Object) Value() Value {
+	return nil
+}
+
+func (m Object) Size() int {
+	return len(m)
 }
 
 // Native converts an object to a generic Go map type (map[string]interface{}).
@@ -167,6 +187,14 @@ func (m Object) Keys() []string {
 	}
 	sort.Strings(keys)
 	return keys
+}
+
+func (m Object) ValueAt(k string) (External, bool) {
+	v, ok := m[k]
+	if !ok {
+		return nil, false
+	}
+	return v, true
 }
 
 // Clone returns a deep copy of an Object.
@@ -205,11 +233,26 @@ func (m *Object) SetNode(n Node) error {
 	return fmt.Errorf("unexpected type: %T", n)
 }
 
-func (m Object) Equal(n Node) bool {
-	if m2, ok := n.(Object); ok {
-		return m.EqualObject(m2)
+func (m Object) Equal(n External) bool {
+	switch n := n.(type) {
+	case nil:
+		return false
+	case Object:
+		return m.EqualObject(n)
+	case Node:
+		// internal node, but not an object
+		return false
+	default:
+		// external node
+		if n.Kind() != KindObject {
+			return false
+		}
+		m2, ok := n.(ExternalObject)
+		if !ok {
+			return false
+		}
+		return m.equalObjectExt(m2)
 	}
-	return false
 }
 
 func (m Object) EqualObject(m2 Object) bool {
@@ -224,13 +267,40 @@ func (m Object) EqualObject(m2 Object) bool {
 	return true
 }
 
+func (m Object) equalObjectExt(m2 ExternalObject) bool {
+	if len(m) != m2.Size() {
+		return false
+	}
+	for _, k := range m2.Keys() {
+		v1, ok := m[k]
+		if !ok {
+			return false
+		}
+		v2, _ := m2.ValueAt(k)
+		if !Equal(v1, v2) {
+			return false
+		}
+	}
+	return true
+}
+
+var _ ExternalArray = Array{}
+
 // Array is an ordered list of nodes.
 type Array []Node
 
 func (Array) isNode() {}
 
-func (Array) kind() Kind {
+func (Array) Kind() Kind {
 	return KindArray
+}
+
+func (Array) Value() Value {
+	return nil
+}
+
+func (m Array) Size() int {
+	return len(m)
 }
 
 // Native converts an array to a generic Go slice type ([]interface{}).
@@ -247,6 +317,13 @@ func (m Array) Native() interface{} {
 		}
 	}
 	return o
+}
+
+func (m Array) ValueAt(i int) External {
+	if i < 0 || i >= len(m) {
+		return nil
+	}
+	return m[i]
 }
 
 // Clone returns a deep copy of an Array.
@@ -267,11 +344,26 @@ func (m Array) CloneList() Array {
 	return out
 }
 
-func (m Array) Equal(n Node) bool {
-	if m2, ok := n.(Array); ok {
-		return m.EqualArray(m2)
+func (m Array) Equal(n External) bool {
+	switch n := n.(type) {
+	case nil:
+		return false
+	case Array:
+		return m.EqualArray(n)
+	case Node:
+		// internal node, but not an array
+		return false
+	default:
+		// external node
+		if n.Kind() != KindArray {
+			return false
+		}
+		m2, ok := n.(ExternalArray)
+		if !ok {
+			return false
+		}
+		return m.equalArrayExt(m2)
 	}
-	return false
 }
 
 func (m Array) EqualArray(m2 Array) bool {
@@ -280,6 +372,19 @@ func (m Array) EqualArray(m2 Array) bool {
 	}
 	for i, v := range m {
 		if !Equal(v, m2[i]) {
+			return false
+		}
+	}
+	return true
+}
+
+func (m Array) equalArrayExt(m2 ExternalArray) bool {
+	if len(m) != m2.Size() {
+		return false
+	}
+	for i, v1 := range m {
+		v2 := m2.ValueAt(i)
+		if !Equal(v1, v2) {
 			return false
 		}
 	}
@@ -299,8 +404,11 @@ type String string
 
 func (String) isNode()  {}
 func (String) isValue() {}
-func (String) kind() Kind {
+func (String) Kind() Kind {
 	return KindString
+}
+func (v String) Value() Value {
+	return v
 }
 
 // Native converts the value to a string.
@@ -313,9 +421,17 @@ func (v String) Clone() Node {
 	return v
 }
 
-func (v String) Equal(n Node) bool {
-	v2, ok := n.(String)
-	return ok && v == v2
+func (v String) Equal(n External) bool {
+	switch n := n.(type) {
+	case nil:
+		return false
+	case String:
+		return v == n
+	case Node:
+		return false
+	default:
+		return v == n.Value()
+	}
 }
 
 func (v *String) SetNode(n Node) error {
@@ -331,8 +447,11 @@ type Int int64
 
 func (Int) isNode()  {}
 func (Int) isValue() {}
-func (Int) kind() Kind {
+func (Int) Kind() Kind {
 	return KindInt
+}
+func (v Int) Value() Value {
+	return v
 }
 
 // Native converts the value to an int64.
@@ -345,8 +464,10 @@ func (v Int) Clone() Node {
 	return v
 }
 
-func (v Int) Equal(n Node) bool {
+func (v Int) Equal(n External) bool {
 	switch n := n.(type) {
+	case nil:
+		return false
 	case Int:
 		return v == n
 	case Uint:
@@ -354,8 +475,11 @@ func (v Int) Equal(n Node) bool {
 			return false
 		}
 		return Uint(v) == n
+	case Node:
+		return false
+	default:
+		return v == n.Value()
 	}
-	return false
 }
 
 func (v *Int) SetNode(n Node) error {
@@ -371,8 +495,11 @@ type Uint uint64
 
 func (Uint) isNode()  {}
 func (Uint) isValue() {}
-func (Uint) kind() Kind {
+func (Uint) Kind() Kind {
 	return KindUint
+}
+func (v Uint) Value() Value {
+	return v
 }
 
 // Native converts the value to an int64.
@@ -385,8 +512,10 @@ func (v Uint) Clone() Node {
 	return v
 }
 
-func (v Uint) Equal(n Node) bool {
+func (v Uint) Equal(n External) bool {
 	switch n := n.(type) {
+	case nil:
+		return false
 	case Uint:
 		return v == n
 	case Int:
@@ -394,8 +523,11 @@ func (v Uint) Equal(n Node) bool {
 			return false
 		}
 		return v == Uint(n)
+	case Node:
+		return false
+	default:
+		return v == n.Value()
 	}
-	return false
 }
 
 func (v *Uint) SetNode(n Node) error {
@@ -411,8 +543,11 @@ type Float float64
 
 func (Float) isNode()  {}
 func (Float) isValue() {}
-func (Float) kind() Kind {
+func (Float) Kind() Kind {
 	return KindFloat
+}
+func (v Float) Value() Value {
+	return v
 }
 
 // Native converts the value to a float64.
@@ -425,9 +560,17 @@ func (v Float) Clone() Node {
 	return v
 }
 
-func (v Float) Equal(n Node) bool {
-	v2, ok := n.(Float)
-	return ok && v == v2
+func (v Float) Equal(n External) bool {
+	switch n := n.(type) {
+	case nil:
+		return false
+	case Float:
+		return v == n
+	case Node:
+		return false
+	default:
+		return v == n.Value()
+	}
 }
 
 func (v *Float) SetNode(n Node) error {
@@ -443,8 +586,11 @@ type Bool bool
 
 func (Bool) isNode()  {}
 func (Bool) isValue() {}
-func (Bool) kind() Kind {
+func (Bool) Kind() Kind {
 	return KindBool
+}
+func (v Bool) Value() Value {
+	return v
 }
 
 // Native converts the value to a bool.
@@ -457,9 +603,17 @@ func (v Bool) Clone() Node {
 	return v
 }
 
-func (v Bool) Equal(n Node) bool {
-	v2, ok := n.(Bool)
-	return ok && v == v2
+func (v Bool) Equal(n External) bool {
+	switch n := n.(type) {
+	case nil:
+		return false
+	case Bool:
+		return v == n
+	case Node:
+		return false
+	default:
+		return v == n.Value()
+	}
 }
 
 func (v *Bool) SetNode(n Node) error {
@@ -479,6 +633,8 @@ func ToNode(o interface{}, fallback ToNodeFunc) (Node, error) {
 		return nil, nil
 	case Node:
 		return o, nil
+	case External:
+		return toNodeExt(o)
 	case map[string]interface{}:
 		n := make(Object, len(o))
 		for k, v := range o {
@@ -558,10 +714,34 @@ func WalkPreOrder(root Node, walk func(Node) bool) {
 	}
 }
 
+// WalkPreOrderExt visits all nodes of the tree in pre-order.
+func WalkPreOrderExt(root External, walk func(External) bool) {
+	if !walk(root) {
+		return
+	}
+	switch KindOf(root) {
+	case KindObject:
+		if n, ok := root.(ExternalObject); ok {
+			for _, k := range n.Keys() {
+				v, _ := n.ValueAt(k)
+				WalkPreOrderExt(v, walk)
+			}
+		}
+	case KindArray:
+		if n, ok := root.(ExternalArray); ok {
+			sz := n.Size()
+			for i := 0; i < sz; i++ {
+				v := n.ValueAt(i)
+				WalkPreOrderExt(v, walk)
+			}
+		}
+	}
+}
+
 // Count returns a number of nodes with given kinds.
-func Count(root Node, kinds Kind) int {
+func Count(root External, kinds Kind) int {
 	var cnt int
-	WalkPreOrder(root, func(n Node) bool {
+	WalkPreOrderExt(root, func(n External) bool {
 		if KindOf(n).In(kinds) {
 			cnt++
 		}

--- a/uast/nodes/node_test.go
+++ b/uast/nodes/node_test.go
@@ -243,6 +243,24 @@ func TestNodeEqual(t *testing.T) {
 	}
 }
 
+func TestNodeEqualExt(t *testing.T) {
+	for _, c := range casesEqual {
+		t.Run(c.name, func(t *testing.T) {
+			n1, n2 := c.n1, c.n2
+			if n2 == nil {
+				n2 = n1
+			}
+			if n1 == nil || n2 == nil {
+				t.SkipNow()
+			}
+			require.Equal(t, c.exp, equalExt(n1, n2))
+			n3, err := toNodeExt(n2)
+			require.NoError(t, err)
+			require.Equal(t, c.exp, Equal(n1, n3))
+		})
+	}
+}
+
 var casesKinds = []struct {
 	n Node
 	k Kind


### PR DESCRIPTION
Since the new libuast version will be written in Go, there is a need to abstract UAST node type that is used in the code to allow to pass different implementations (implemented by client languages).

This CL defines a new `nodes.External` interface that will be implemented by native nodes, and checks for this kind of nodes in `ToNode`, so existing code will be able to handle external nodes at least by copying them.

It also updates `KindOf`, `Count` and `WalkPreOrder` functions to support external nodes instead of accepting only native ones.

Signed-off-by: Denys Smirnov <denys@sourced.tech>