### PR TITLE
Revert v1 mode from Semantic to Annotated UAST

### DIFF
--- a/driver/server/grpc.go
+++ b/driver/server/grpc.go
@@ -120,7 +120,7 @@ func (s service) parse(mode driver.Mode, req *protocol1.ParseRequest) (nodes.Nod
 }
 
 func (s service) Parse(req *protocol1.ParseRequest) *protocol1.ParseResponse {
-	ast, resp := s.parse(driver.ModeSemantic, req)
+	ast, resp := s.parse(driver.ModeAnnotated, req)
 	if resp.Status != protocol1.Ok {
 		return &protocol1.ParseResponse{Response: resp}
 	}


### PR DESCRIPTION
To test Semantic UAST in new drivers we set the default transformation mode for v1 protocol to Semantic.

But now we want to release v2 drivers without breaking old v1 clients, so it makes sense to revert the mode back to Annotated.

The latest [change](https://github.com/bblfsh/client-go/pull/77) in Go client allows clients to change the mode to Semantic but still receive an old UAST format to preserve compatibility, so we will still be able to use it.

This change will require to update all drivers before releasing them.

Signed-off-by: Denys Smirnov <denys@sourced.tech>