### PR TITLE
Push drivers to the latest Docker tag

### DIFF
--- a/build/push.go
+++ b/build/push.go
@@ -2,6 +2,7 @@ package build
 
 import (
 	"fmt"
+	"log"
 	"os"
 	"os/exec"
 	"regexp"
@@ -22,6 +23,9 @@ func pushLatestEnabled() bool {
 }
 
 func (d *Driver) Push(image string) error {
+	if isCI() {
+		log.Printf("CI variables: branch=%q, tag=%q, pr=%v", ciBranch(), ciTag(), ciIsPR())
+	}
 	if !pushTagEnabled() && !pushLatestEnabled() {
 		return fmt.Errorf("push disabled")
 	} else if image == "" {

--- a/build/push.go
+++ b/build/push.go
@@ -10,15 +10,15 @@ import (
 var reVers = regexp.MustCompile(`^v\d+`)
 
 func pushEnabled() bool {
-	return ciTag() != "" && !ciIsPR()
+	return !ciIsPR() && (ciBranch() == "master" || ciTag() != "")
 }
 
 func pushTagEnabled() bool {
-	return pushEnabled() && reVers.MatchString(ciBranch())
+	return pushEnabled() && (reVers.MatchString(ciBranch()) || reVers.MatchString(ciTag()))
 }
 
 func pushLatestEnabled() bool {
-	return ciBranch() == "master" && pushEnabled()
+	return pushEnabled() && ciTag() != ""
 }
 
 func (d *Driver) Push(image string) error {


### PR DESCRIPTION
We are now ready to publish v2 drivers, thus we need to allow build scripts in SDK to push the `latest` tag to Docker hub.

To be on the safe side, I also print the variables that were used to make a decision to push. It seems like something weird happens with those vars during the merge to `master` and publishing a release.