### PR TITLE
Implement XPath filtering and iterators

### DIFF
--- a/uast/query/iter.go
+++ b/uast/query/iter.go
@@ -1,0 +1,211 @@
+package query
+
+import (
+	"fmt"
+
+	"gopkg.in/bblfsh/sdk.v2/uast/nodes"
+)
+
+var _ Iterator = Empty{}
+
+type Empty struct{}
+
+func (Empty) Next() bool           { return false }
+func (Empty) Node() nodes.External { return nil }
+
+type IterOrder int
+
+const (
+	IterAny = IterOrder(iota)
+	PreOrder
+	PostOrder
+	LevelOrder
+	PositionOrder
+)
+
+func NewIterator(root nodes.External, order IterOrder) Iterator {
+	if root == nil {
+		return Empty{}
+	}
+	if order == IterAny {
+		order = PreOrder
+	}
+	switch order {
+	case PreOrder:
+		it := &preOrderIter{}
+		it.push(root)
+		return it
+	case PostOrder:
+		it := &postOrderIter{}
+		it.start(root)
+		return it
+	case LevelOrder:
+		return &levelOrderIter{level: []nodes.External{root}, i: -1}
+	default:
+		panic(fmt.Errorf("unsupported iterator order: %v", order))
+	}
+}
+
+func eachChild(n nodes.External, fnc func(v nodes.External)) {
+	switch nodes.KindOf(n) {
+	case nodes.KindObject:
+		if m, ok := n.(nodes.ExternalObject); ok {
+			keys := m.Keys()
+			for _, k := range keys {
+				if v, _ := m.ValueAt(k); v != nil {
+					fnc(v)
+				}
+			}
+		}
+	case nodes.KindArray:
+		if m, ok := n.(nodes.ExternalArray); ok {
+			sz := m.Size()
+			for i := 0; i < sz; i++ {
+				if v := m.ValueAt(i); v != nil {
+					fnc(v)
+				}
+			}
+		}
+	}
+}
+
+func eachChildRev(n nodes.External, fnc func(v nodes.External)) {
+	switch nodes.KindOf(n) {
+	case nodes.KindObject:
+		if m, ok := n.(nodes.ExternalObject); ok {
+			keys := m.Keys()
+			// reverse order
+			for i := len(keys) - 1; i >= 0; i-- {
+				if v, _ := m.ValueAt(keys[i]); v != nil {
+					fnc(v)
+				}
+			}
+		}
+	case nodes.KindArray:
+		if m, ok := n.(nodes.ExternalArray); ok {
+			sz := m.Size()
+			// reverse order
+			for i := sz - 1; i >= 0; i-- {
+				if v := m.ValueAt(i); v != nil {
+					fnc(v)
+				}
+			}
+		}
+	}
+}
+
+type preOrderIter struct {
+	cur nodes.External
+	q   []nodes.External
+}
+
+func (it *preOrderIter) push(n nodes.External) {
+	if n == nil {
+		return
+	}
+	it.q = append(it.q, n)
+}
+func (it *preOrderIter) pop() nodes.External {
+	l := len(it.q)
+	if l == 0 {
+		return nil
+	}
+	n := it.q[l-1]
+	it.q = it.q[:l-1]
+	return n
+}
+
+func (it *preOrderIter) Next() bool {
+	cur := it.cur
+	it.cur = nil
+	eachChildRev(cur, it.push)
+	it.cur = it.pop()
+	return nodes.KindOf(it.cur) != nodes.KindNil
+}
+func (it *preOrderIter) Node() nodes.External {
+	return it.cur
+}
+
+type postOrderIter struct {
+	cur nodes.External
+	s   [][]nodes.External
+}
+
+func (it *postOrderIter) start(n nodes.External) {
+	kind := nodes.KindOf(n)
+	if kind == nodes.KindNil {
+		return
+	}
+	si := len(it.s)
+	q := []nodes.External{n}
+	it.s = append(it.s, nil)
+	eachChildRev(n, func(v nodes.External) {
+		q = append(q, v)
+	})
+	if l := len(q); l > 1 {
+		it.start(q[l-1])
+		q = q[:l-1]
+	}
+	it.s[si] = q
+}
+
+func (it *postOrderIter) Next() bool {
+	down := false
+	for {
+		l := len(it.s)
+		if l == 0 {
+			return false
+		}
+		l--
+		top := it.s[l]
+		if len(top) == 0 {
+			it.s = it.s[:l]
+			down = true
+			continue
+		}
+		i := len(top) - 1
+		if down && i > 0 {
+			down = false
+			n := top[i]
+			it.s[l] = top[:i]
+			it.start(n)
+			continue
+		}
+		down = false
+		it.cur = top[i]
+		it.s[l] = top[:i]
+		return true
+	}
+}
+func (it *postOrderIter) Node() nodes.External {
+	return it.cur
+}
+
+type levelOrderIter struct {
+	level []nodes.External
+	i     int
+}
+
+func (it *levelOrderIter) Next() bool {
+	if len(it.level) == 0 {
+		return false
+	} else if it.i+1 < len(it.level) {
+		it.i++
+		return true
+	}
+	var next []nodes.External
+	for _, n := range it.level {
+		eachChild(n, func(v nodes.External) {
+			next = append(next, v)
+		})
+	}
+	it.i = 0
+	it.level = next
+	return len(it.level) > 0
+}
+func (it *levelOrderIter) Node() nodes.External {
+	if it.i >= len(it.level) {
+		return nil
+	}
+	return it.level[it.i]
+}

--- a/uast/query/iter_test.go
+++ b/uast/query/iter_test.go
@@ -1,0 +1,76 @@
+package query
+
+import (
+	"testing"
+
+	"gopkg.in/bblfsh/sdk.v2/uast/nodes"
+)
+
+func TestIterPreOrder(t *testing.T) {
+	a := nodes.Object{
+		"k1": nodes.Int(1),
+		"k2": nodes.Int(2),
+	}
+	b := nodes.String("v")
+	root := nodes.Array{a, b}
+
+	it := NewIterator(root, PreOrder)
+	got := allNodes(it)
+	exp := []nodes.Node{
+		root,
+		a, nodes.Int(1), nodes.Int(2),
+		b,
+	}
+	if !nodes.Equal(nodes.Array(exp), nodes.Array(got)) {
+		t.Fatalf("wrong order: %v", got)
+	}
+}
+
+func TestIterPostOrder(t *testing.T) {
+	a := nodes.Object{
+		"k1": nodes.Int(1),
+		"k2": nodes.Int(2),
+	}
+	b := nodes.String("v")
+	root := nodes.Array{a, b}
+
+	it := NewIterator(root, PostOrder)
+	got := allNodes(it)
+	exp := []nodes.Node{
+		nodes.Int(1), nodes.Int(2), a,
+		b,
+		root,
+	}
+	if !nodes.Equal(nodes.Array(exp), nodes.Array(got)) {
+		t.Fatalf("wrong order: %v", got)
+	}
+}
+
+func TestIterLevelOrder(t *testing.T) {
+	a := nodes.Object{
+		"k1": nodes.Int(1),
+		"k2": nodes.Int(2),
+	}
+	b := nodes.String("v")
+	root := nodes.Array{a, b}
+
+	it := NewIterator(root, LevelOrder)
+	got := allNodes(it)
+	exp := []nodes.Node{
+		root,
+		a, b,
+		nodes.Int(1), nodes.Int(2),
+	}
+	if !nodes.Equal(nodes.Array(exp), nodes.Array(got)) {
+		t.Fatalf("wrong order: %v", got)
+	}
+}
+
+func allNodes(it Iterator) []nodes.Node {
+	var out []nodes.Node
+	for it.Next() {
+		n, _ := it.Node().(nodes.Node)
+		out = append(out, n)
+	}
+	return out
+}

--- a/uast/query/query.go
+++ b/uast/query/query.go
@@ -1,0 +1,42 @@
+package query
+
+import (
+	"gopkg.in/bblfsh/sdk.v2/uast/nodes"
+)
+
+type Interface interface {
+	// Prepare parses the query and prepares it for repeated execution.
+	Prepare(query string) (Query, error)
+	// Execute prepares and runs a query for a given subtree.
+	Execute(root nodes.External, query string) (Iterator, error)
+}
+
+type Query interface {
+	// Execute runs a query for a given subtree.
+	Execute(root nodes.External) (Iterator, error)
+}
+
+type Iterator interface {
+	// Next advances an iterator.
+	Next() bool
+	// Node returns a current node.
+	Node() nodes.External
+}
+
+// AllNodes iterates over all nodes and returns them as a slice.
+func AllNodes(it Iterator) []nodes.External {
+	var out []nodes.External
+	for it.Next() {
+		out = append(out, it.Node())
+	}
+	return out
+}
+
+// Count counts the nodes in the iterator. Iterator will be exhausted as a result.
+func Count(it Iterator) int {
+	var n int
+	for it.Next() {
+		n++
+	}
+	return n
+}

--- a/uast/query/xpath/node.go
+++ b/uast/query/xpath/node.go
@@ -1,0 +1,131 @@
+package xpath
+
+import (
+	"bytes"
+	"fmt"
+
+	"gopkg.in/bblfsh/sdk.v2/uast/nodes"
+)
+
+// A nodeType is the type of a node.
+type nodeType uint
+
+const (
+	// documentNode is a document object that, as the root of the document tree,
+	// provides access to the entire XML document.
+	documentNode nodeType = iota
+	// elementNode is an element.
+	elementNode
+	// textNode is the text content of a node.
+	textNode
+)
+
+// A node consists of a nodeType and some Data (tag name for
+// element nodes, content for text) and are part of a tree of Nodes.
+type node struct {
+	Parent, PrevSibling, NextSibling, FirstChild, LastChild *node
+
+	Type nodeType
+	Data string
+	Node nodes.External
+
+	level int
+}
+
+// ChildNodes gets all child nodes of the node.
+func (n *node) ChildNodes() []*node {
+	var a []*node
+	for nn := n.FirstChild; nn != nil; nn = nn.NextSibling {
+		a = append(a, nn)
+	}
+	return a
+}
+
+// InnerText gets the value of the node and all its child nodes.
+func (n *node) InnerText() string {
+	var output func(*bytes.Buffer, *node)
+	output = func(buf *bytes.Buffer, n *node) {
+		if n.Type == textNode {
+			buf.WriteString(n.Data)
+			return
+		}
+		for child := n.FirstChild; child != nil; child = child.NextSibling {
+			output(buf, child)
+		}
+	}
+	var buf bytes.Buffer
+	output(&buf, n)
+	return buf.String()
+}
+
+// SelectElement finds the first of child elements with the
+// specified name.
+func (n *node) SelectElement(name string) *node {
+	for nn := n.FirstChild; nn != nil; nn = nn.NextSibling {
+		if nn.Data == name {
+			return nn
+		}
+	}
+	return nil
+}
+
+func parseValue(x nodes.External, top *node, level int) {
+	top.Node = x
+	addNode := func(n *node) {
+		if n.level == top.level {
+			top.NextSibling = n
+			n.PrevSibling = top
+			n.Parent = top.Parent
+			if top.Parent != nil {
+				top.Parent.LastChild = n
+			}
+		} else if n.level > top.level {
+			n.Parent = top
+			if top.FirstChild == nil {
+				top.FirstChild = n
+				top.LastChild = n
+			} else {
+				t := top.LastChild
+				t.NextSibling = n
+				n.PrevSibling = t
+				top.LastChild = n
+			}
+		}
+	}
+	if x == nil {
+		return
+	}
+	switch kind := x.Kind(); kind {
+	case nodes.KindArray:
+		if x, ok := x.(nodes.ExternalArray); ok {
+			sz := x.Size()
+			for i := 0; i < sz; i++ {
+				vv := x.ValueAt(i)
+				n := &node{Type: elementNode, level: level, Node: vv}
+				addNode(n)
+				parseValue(vv, n, level+1)
+			}
+		}
+	case nodes.KindObject:
+		if x, ok := x.(nodes.ExternalObject); ok {
+			for _, key := range x.Keys() {
+				vv, _ := x.ValueAt(key)
+				n := &node{Data: key, Type: elementNode, level: level, Node: vv}
+				addNode(n)
+				parseValue(vv, n, level+1)
+			}
+		}
+	default:
+		if isValue(x) {
+			s := fmt.Sprint(x.Value())
+			n := &node{Data: s, Type: textNode, level: level, Node: x}
+			addNode(n)
+		}
+	}
+}
+
+func conv(v nodes.External) *node {
+	doc := &node{Type: documentNode, Node: v}
+	parseValue(v, doc, 1)
+	return doc
+}

--- a/uast/query/xpath/query.go
+++ b/uast/query/xpath/query.go
@@ -1,0 +1,132 @@
+package xpath
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/antchfx/xpath"
+	"gopkg.in/bblfsh/sdk.v2/uast"
+)
+
+var _ xpath.NodeNavigator = &nodeNavigator{}
+
+// newNavigator creates a new xpath.nodeNavigator for the specified html.node.
+func newNavigator(top *node) *nodeNavigator {
+	return &nodeNavigator{cur: top, root: top}
+}
+
+// nodeNavigator is for navigating JSON document.
+type nodeNavigator struct {
+	root, cur *node
+}
+
+func (a *nodeNavigator) Current() *node {
+	return a.cur
+}
+
+func (a *nodeNavigator) NodeType() xpath.NodeType {
+	switch a.cur.Type {
+	case textNode:
+		return xpath.TextNode
+	case documentNode:
+		return xpath.RootNode
+	case elementNode:
+		return xpath.ElementNode
+	default:
+		panic(fmt.Sprintf("unknown node type %v", a.cur.Type))
+	}
+}
+
+func (a *nodeNavigator) getType() [2]string {
+	typ := uast.TypeOf(a.cur.Node)
+	if typ == "" {
+		return [2]string{"", a.cur.Data}
+	}
+	i := strings.Index(typ, ":")
+	if i < 0 {
+		return [2]string{"", typ}
+	}
+	return [2]string{typ[:i], typ[i+1:]}
+}
+func (a *nodeNavigator) LocalName() string {
+	return a.getType()[1]
+}
+
+func (a *nodeNavigator) Prefix() string {
+	return a.getType()[0]
+}
+
+func (a *nodeNavigator) Value() string {
+	switch a.cur.Type {
+	case elementNode:
+		return a.cur.InnerText()
+	case textNode:
+		return a.cur.Data
+	}
+	return ""
+}
+
+func (a *nodeNavigator) Copy() xpath.NodeNavigator {
+	n := *a
+	return &n
+}
+
+func (a *nodeNavigator) MoveToRoot() {
+	a.cur = a.root
+}
+
+func (a *nodeNavigator) MoveToParent() bool {
+	if n := a.cur.Parent; n != nil {
+		a.cur = n
+		return true
+	}
+	return false
+}
+
+func (x *nodeNavigator) MoveToNextAttribute() bool {
+	return false
+}
+
+func (a *nodeNavigator) MoveToChild() bool {
+	if n := a.cur.FirstChild; n != nil {
+		a.cur = n
+		return true
+	}
+	return false
+}
+
+func (a *nodeNavigator) MoveToFirst() bool {
+	for n := a.cur.PrevSibling; n != nil; n = n.PrevSibling {
+		a.cur = n
+	}
+	return true
+}
+
+func (a *nodeNavigator) String() string {
+	return a.Value()
+}
+
+func (a *nodeNavigator) MoveToNext() bool {
+	if n := a.cur.NextSibling; n != nil {
+		a.cur = n
+		return true
+	}
+	return false
+}
+
+func (a *nodeNavigator) MoveToPrevious() bool {
+	if n := a.cur.PrevSibling; n != nil {
+		a.cur = n
+		return true
+	}
+	return false
+}
+
+func (a *nodeNavigator) MoveTo(other xpath.NodeNavigator) bool {
+	node, ok := other.(*nodeNavigator)
+	if !ok || node.root != a.root {
+		return false
+	}
+	a.cur = node.cur
+	return true
+}

--- a/uast/query/xpath/query_test.go
+++ b/uast/query/xpath/query_test.go
@@ -1,0 +1,41 @@
+package xpath
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"gopkg.in/bblfsh/sdk.v2/uast"
+	"gopkg.in/bblfsh/sdk.v2/uast/nodes"
+	"gopkg.in/bblfsh/sdk.v2/uast/query"
+)
+
+func toNode(o interface{}) nodes.Node {
+	n, err := uast.ToNode(o)
+	if err != nil {
+		panic(err)
+	}
+	return n
+}
+
+func TestFilter(t *testing.T) {
+	var root = nodes.Array{
+		toNode(uast.Identifier{Name: "Foo"}),
+	}
+
+	idx := New()
+	it, err := idx.Execute(root, "//uast:Identifier[Name='Foo']")
+	require.NoError(t, err)
+	expect(t, it, root[0])
+
+	it, err = idx.Execute(root, "//Identifier")
+	require.NoError(t, err)
+	expect(t, it)
+}
+
+func expect(t testing.TB, it query.Iterator, exp ...nodes.Node) {
+	var out []nodes.Node
+	for it.Next() {
+		out = append(out, it.Node().(nodes.Node))
+	}
+	require.Equal(t, exp, out)
+}

--- a/uast/query/xpath/xpath.go
+++ b/uast/query/xpath/xpath.go
@@ -1,0 +1,74 @@
+package xpath
+
+import (
+	"github.com/antchfx/xpath"
+	"gopkg.in/bblfsh/sdk.v2/uast/nodes"
+	"gopkg.in/bblfsh/sdk.v2/uast/query"
+)
+
+func isValue(n nodes.External) bool {
+	if n == nil {
+		return false
+	}
+	k := n.Kind()
+	return k.In(nodes.KindsValues)
+}
+
+func New() query.Interface {
+	return &index{}
+}
+
+type index struct{}
+
+func (t *index) newNavigator(n nodes.External) xpath.NodeNavigator {
+	// TODO: zero copy
+	d := conv(n)
+	return newNavigator(d)
+}
+
+func (t *index) Prepare(query string) (query.Query, error) {
+	exp, err := xpath.Compile(query)
+	if err != nil {
+		return nil, err
+	}
+	return &xQuery{idx: t, exp: exp}, nil
+}
+
+func (t *index) Execute(root nodes.External, query string) (query.Iterator, error) {
+	q, err := t.Prepare(query)
+	if err != nil {
+		return nil, err
+	}
+	return q.Execute(root)
+}
+
+type xQuery struct {
+	idx *index
+	exp *xpath.Expr
+}
+
+func (q *xQuery) Execute(root nodes.External) (query.Iterator, error) {
+	nav := q.idx.newNavigator(root)
+	it := q.exp.Select(nav)
+	return &iterator{it: it}, nil
+}
+
+type iterator struct {
+	it *xpath.NodeIterator
+}
+
+func (it *iterator) Next() bool {
+	return it.it.MoveNext()
+}
+
+func (it *iterator) Node() nodes.External {
+	c := it.it.Current()
+	if c == nil {
+		return nil
+	}
+	nav := c.(*nodeNavigator)
+	if nav.cur == nil {
+		return nil
+	}
+	return nav.cur.Node
+}


### PR DESCRIPTION
Implement XPath filtering and iterators in the SDK. It will be exposed to the new libuast and the Go client.

Work in progress.

**TODO:**
- [ ] Implement position order iterator
- [ ] Implement correct XPath projection
- [ ] Add documentation

Signed-off-by: Denys Smirnov <denys@sourced.tech>