### PR TITLE
Move iterators to the nodes package and implement positional iterator

### DIFF
--- a/uast/iter.go
+++ b/uast/iter.go
@@ -1,0 +1,97 @@
+package uast
+
+import (
+	"sort"
+
+	"gopkg.in/bblfsh/sdk.v2/uast/nodes"
+)
+
+// NewPositionalIterator creates a new iterator that enumerates all object nodes, sorting them by positions in the source file.
+// Nodes with no positions will be enumerated last.
+func NewPositionalIterator(root nodes.External) nodes.Iterator {
+	return &positionIter{root: root}
+}
+
+type positionIter struct {
+	root  nodes.External
+	nodes []nodes.External
+}
+
+type nodesByPos struct {
+	nodes []nodes.External
+	pos   []Position
+}
+
+func (arr nodesByPos) Len() int {
+	return len(arr.nodes)
+}
+
+func (arr nodesByPos) Less(i, j int) bool {
+	return arr.pos[i].Less(arr.pos[j])
+}
+
+func (arr nodesByPos) Swap(i, j int) {
+	arr.nodes[i], arr.nodes[j] = arr.nodes[j], arr.nodes[i]
+	arr.pos[i], arr.pos[j] = arr.pos[j], arr.pos[i]
+}
+
+func (it *positionIter) sort() {
+	// in general, we cannot expect that parent node's positional info will include all the children
+	// because of this we are forced to enumerate all nodes and sort them by positions on the first call to Next
+	var plist []Position
+	noPos := func() {
+		plist = append(plist, Position{})
+	}
+	posType := TypeOf(Positions{})
+	nodes.WalkPreOrderExt(it.root, func(n nodes.External) bool {
+		if n == nil || n.Kind() != nodes.KindObject {
+			return true
+		}
+		obj, ok := n.(nodes.ExternalObject)
+		if !ok {
+			return true
+		}
+		if TypeOf(n) == posType {
+			// skip position nodes
+			return false
+		}
+		it.nodes = append(it.nodes, n)
+		m, _ := obj.ValueAt(KeyPos)
+		if m == nil || m.Kind() != nodes.KindObject {
+			noPos()
+			return true
+		}
+		var ps Positions
+		if err := NodeAs(m, &ps); err != nil {
+			noPos()
+			return true
+		}
+		if p := ps.Start(); p != nil {
+			plist = append(plist, *p)
+		} else {
+			noPos()
+		}
+		return true
+	})
+	sort.Sort(nodesByPos{nodes: it.nodes, pos: plist})
+	plist = nil
+}
+
+func (it *positionIter) Next() bool {
+	if it.nodes == nil {
+		it.sort()
+		return len(it.nodes) != 0
+	}
+	if len(it.nodes) == 0 {
+		return false
+	}
+	it.nodes = it.nodes[1:]
+	return len(it.nodes) != 0
+}
+
+func (it *positionIter) Node() nodes.External {
+	if len(it.nodes) == 0 {
+		return nil
+	}
+	return it.nodes[0]
+}

--- a/uast/iter_test.go
+++ b/uast/iter_test.go
@@ -1,0 +1,54 @@
+package uast
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"gopkg.in/bblfsh/sdk.v2/uast/nodes"
+)
+
+func toNode(o interface{}) nodes.Node {
+	n, err := ToNode(o)
+	if err != nil {
+		panic(err)
+	}
+	return n
+}
+
+func pos(off, line, col uint32) GenNode {
+	return GenNode{
+		Positions: Positions{
+			KeyStart: Position{Offset: off, Line: line, Col: col},
+		},
+	}
+}
+
+func expect(t testing.TB, it nodes.Iterator, exp ...nodes.External) {
+	var got []nodes.External
+	for it.Next() {
+		got = append(got, it.Node())
+	}
+	require.Equal(t, len(exp), len(got), "%v", got)
+	require.Equal(t, exp, got)
+}
+
+func TestPosIterator(t *testing.T) {
+	root := nodes.Array{
+		toNode(Identifier{
+			GenNode: pos(3, 4, 1),
+			Name:    "A",
+		}),
+		toNode(Identifier{
+			GenNode: pos(0, 1, 1),
+			Name:    "B",
+		}),
+		toNode(Identifier{
+			GenNode: pos(0, 0, 0),
+			Name:    "C",
+		}),
+	}
+	a, b, c := root[0], root[1], root[2]
+	it := NewPositionalIterator(root)
+	expect(t, it, b, a, c)
+}

--- a/uast/nodes/iter.go
+++ b/uast/nodes/iter.go
@@ -1,0 +1,213 @@
+package nodes
+
+import "fmt"
+
+type Iterator interface {
+	// Next advances an iterator.
+	Next() bool
+	// Node returns a current node.
+	Node() External
+}
+
+var _ Iterator = Empty{}
+
+type Empty struct{}
+
+func (Empty) Next() bool     { return false }
+func (Empty) Node() External { return nil }
+
+type IterOrder int
+
+const (
+	IterAny = IterOrder(iota)
+	PreOrder
+	PostOrder
+	LevelOrder
+)
+
+func NewIterator(root External, order IterOrder) Iterator {
+	if root == nil {
+		return Empty{}
+	}
+	if order == IterAny {
+		order = PreOrder
+	}
+	switch order {
+	case PreOrder:
+		it := &preOrderIter{}
+		it.push(root)
+		return it
+	case PostOrder:
+		it := &postOrderIter{}
+		it.start(root)
+		return it
+	case LevelOrder:
+		return &levelOrderIter{level: []External{root}, i: -1}
+	default:
+		panic(fmt.Errorf("unsupported iterator order: %v", order))
+	}
+}
+
+func eachChild(n External, fnc func(v External)) {
+	switch KindOf(n) {
+	case KindObject:
+		if m, ok := n.(ExternalObject); ok {
+			keys := m.Keys()
+			for _, k := range keys {
+				if v, _ := m.ValueAt(k); v != nil {
+					fnc(v)
+				}
+			}
+		}
+	case KindArray:
+		if m, ok := n.(ExternalArray); ok {
+			sz := m.Size()
+			for i := 0; i < sz; i++ {
+				if v := m.ValueAt(i); v != nil {
+					fnc(v)
+				}
+			}
+		}
+	}
+}
+
+func eachChildRev(n External, fnc func(v External)) {
+	switch KindOf(n) {
+	case KindObject:
+		if m, ok := n.(ExternalObject); ok {
+			keys := m.Keys()
+			// reverse order
+			for i := len(keys) - 1; i >= 0; i-- {
+				if v, _ := m.ValueAt(keys[i]); v != nil {
+					fnc(v)
+				}
+			}
+		}
+	case KindArray:
+		if m, ok := n.(ExternalArray); ok {
+			sz := m.Size()
+			// reverse order
+			for i := sz - 1; i >= 0; i-- {
+				if v := m.ValueAt(i); v != nil {
+					fnc(v)
+				}
+			}
+		}
+	}
+}
+
+type preOrderIter struct {
+	cur External
+	q   []External
+}
+
+func (it *preOrderIter) push(n External) {
+	if n == nil {
+		return
+	}
+	it.q = append(it.q, n)
+}
+func (it *preOrderIter) pop() External {
+	l := len(it.q)
+	if l == 0 {
+		return nil
+	}
+	n := it.q[l-1]
+	it.q = it.q[:l-1]
+	return n
+}
+
+func (it *preOrderIter) Next() bool {
+	cur := it.cur
+	it.cur = nil
+	eachChildRev(cur, it.push)
+	it.cur = it.pop()
+	return KindOf(it.cur) != KindNil
+}
+func (it *preOrderIter) Node() External {
+	return it.cur
+}
+
+type postOrderIter struct {
+	cur External
+	s   [][]External
+}
+
+func (it *postOrderIter) start(n External) {
+	kind := KindOf(n)
+	if kind == KindNil {
+		return
+	}
+	si := len(it.s)
+	q := []External{n}
+	it.s = append(it.s, nil)
+	eachChildRev(n, func(v External) {
+		q = append(q, v)
+	})
+	if l := len(q); l > 1 {
+		it.start(q[l-1])
+		q = q[:l-1]
+	}
+	it.s[si] = q
+}
+
+func (it *postOrderIter) Next() bool {
+	down := false
+	for {
+		l := len(it.s)
+		if l == 0 {
+			return false
+		}
+		l--
+		top := it.s[l]
+		if len(top) == 0 {
+			it.s = it.s[:l]
+			down = true
+			continue
+		}
+		i := len(top) - 1
+		if down && i > 0 {
+			down = false
+			n := top[i]
+			it.s[l] = top[:i]
+			it.start(n)
+			continue
+		}
+		down = false
+		it.cur = top[i]
+		it.s[l] = top[:i]
+		return true
+	}
+}
+func (it *postOrderIter) Node() External {
+	return it.cur
+}
+
+type levelOrderIter struct {
+	level []External
+	i     int
+}
+
+func (it *levelOrderIter) Next() bool {
+	if len(it.level) == 0 {
+		return false
+	} else if it.i+1 < len(it.level) {
+		it.i++
+		return true
+	}
+	var next []External
+	for _, n := range it.level {
+		eachChild(n, func(v External) {
+			next = append(next, v)
+		})
+	}
+	it.i = 0
+	it.level = next
+	return len(it.level) > 0
+}
+func (it *levelOrderIter) Node() External {
+	if it.i >= len(it.level) {
+		return nil
+	}
+	return it.level[it.i]
+}

--- a/uast/nodes/iter_test.go
+++ b/uast/nodes/iter_test.go
@@ -1,4 +1,4 @@
-package query
+package nodes_test
 
 import (
 	"testing"
@@ -14,7 +14,7 @@ func TestIterPreOrder(t *testing.T) {
 	b := nodes.String("v")
 	root := nodes.Array{a, b}
 
-	it := NewIterator(root, PreOrder)
+	it := nodes.NewIterator(root, nodes.PreOrder)
 	got := allNodes(it)
 	exp := []nodes.Node{
 		root,
@@ -34,7 +34,7 @@ func TestIterPostOrder(t *testing.T) {
 	b := nodes.String("v")
 	root := nodes.Array{a, b}
 
-	it := NewIterator(root, PostOrder)
+	it := nodes.NewIterator(root, nodes.PostOrder)
 	got := allNodes(it)
 	exp := []nodes.Node{
 		nodes.Int(1), nodes.Int(2), a,
@@ -54,7 +54,7 @@ func TestIterLevelOrder(t *testing.T) {
 	b := nodes.String("v")
 	root := nodes.Array{a, b}
 
-	it := NewIterator(root, LevelOrder)
+	it := nodes.NewIterator(root, nodes.LevelOrder)
 	got := allNodes(it)
 	exp := []nodes.Node{
 		root,
@@ -66,7 +66,7 @@ func TestIterLevelOrder(t *testing.T) {
 	}
 }
 
-func allNodes(it Iterator) []nodes.Node {
+func allNodes(it nodes.Iterator) []nodes.Node {
 	var out []nodes.Node
 	for it.Next() {
 		n, _ := it.Node().(nodes.Node)

--- a/uast/query/iter.go
+++ b/uast/query/iter.go
@@ -1,211 +1,29 @@
 package query
 
 import (
-	"fmt"
-
+	"gopkg.in/bblfsh/sdk.v2/uast"
 	"gopkg.in/bblfsh/sdk.v2/uast/nodes"
 )
 
-var _ Iterator = Empty{}
+type Empty = nodes.Empty
 
-type Empty struct{}
-
-func (Empty) Next() bool           { return false }
-func (Empty) Node() nodes.External { return nil }
-
-type IterOrder int
+type IterOrder = nodes.IterOrder
 
 const (
-	IterAny = IterOrder(iota)
-	PreOrder
-	PostOrder
-	LevelOrder
-	PositionOrder
+	IterAny       = nodes.IterAny
+	PreOrder      = nodes.PreOrder
+	PostOrder     = nodes.PostOrder
+	LevelOrder    = nodes.LevelOrder
+	PositionOrder = LevelOrder + iota + 1
 )
 
 func NewIterator(root nodes.External, order IterOrder) Iterator {
 	if root == nil {
 		return Empty{}
 	}
-	if order == IterAny {
-		order = PreOrder
-	}
 	switch order {
-	case PreOrder:
-		it := &preOrderIter{}
-		it.push(root)
-		return it
-	case PostOrder:
-		it := &postOrderIter{}
-		it.start(root)
-		return it
-	case LevelOrder:
-		return &levelOrderIter{level: []nodes.External{root}, i: -1}
-	default:
-		panic(fmt.Errorf("unsupported iterator order: %v", order))
+	case PositionOrder:
+		return uast.NewPositionalIterator(root)
 	}
-}
-
-func eachChild(n nodes.External, fnc func(v nodes.External)) {
-	switch nodes.KindOf(n) {
-	case nodes.KindObject:
-		if m, ok := n.(nodes.ExternalObject); ok {
-			keys := m.Keys()
-			for _, k := range keys {
-				if v, _ := m.ValueAt(k); v != nil {
-					fnc(v)
-				}
-			}
-		}
-	case nodes.KindArray:
-		if m, ok := n.(nodes.ExternalArray); ok {
-			sz := m.Size()
-			for i := 0; i < sz; i++ {
-				if v := m.ValueAt(i); v != nil {
-					fnc(v)
-				}
-			}
-		}
-	}
-}
-
-func eachChildRev(n nodes.External, fnc func(v nodes.External)) {
-	switch nodes.KindOf(n) {
-	case nodes.KindObject:
-		if m, ok := n.(nodes.ExternalObject); ok {
-			keys := m.Keys()
-			// reverse order
-			for i := len(keys) - 1; i >= 0; i-- {
-				if v, _ := m.ValueAt(keys[i]); v != nil {
-					fnc(v)
-				}
-			}
-		}
-	case nodes.KindArray:
-		if m, ok := n.(nodes.ExternalArray); ok {
-			sz := m.Size()
-			// reverse order
-			for i := sz - 1; i >= 0; i-- {
-				if v := m.ValueAt(i); v != nil {
-					fnc(v)
-				}
-			}
-		}
-	}
-}
-
-type preOrderIter struct {
-	cur nodes.External
-	q   []nodes.External
-}
-
-func (it *preOrderIter) push(n nodes.External) {
-	if n == nil {
-		return
-	}
-	it.q = append(it.q, n)
-}
-func (it *preOrderIter) pop() nodes.External {
-	l := len(it.q)
-	if l == 0 {
-		return nil
-	}
-	n := it.q[l-1]
-	it.q = it.q[:l-1]
-	return n
-}
-
-func (it *preOrderIter) Next() bool {
-	cur := it.cur
-	it.cur = nil
-	eachChildRev(cur, it.push)
-	it.cur = it.pop()
-	return nodes.KindOf(it.cur) != nodes.KindNil
-}
-func (it *preOrderIter) Node() nodes.External {
-	return it.cur
-}
-
-type postOrderIter struct {
-	cur nodes.External
-	s   [][]nodes.External
-}
-
-func (it *postOrderIter) start(n nodes.External) {
-	kind := nodes.KindOf(n)
-	if kind == nodes.KindNil {
-		return
-	}
-	si := len(it.s)
-	q := []nodes.External{n}
-	it.s = append(it.s, nil)
-	eachChildRev(n, func(v nodes.External) {
-		q = append(q, v)
-	})
-	if l := len(q); l > 1 {
-		it.start(q[l-1])
-		q = q[:l-1]
-	}
-	it.s[si] = q
-}
-
-func (it *postOrderIter) Next() bool {
-	down := false
-	for {
-		l := len(it.s)
-		if l == 0 {
-			return false
-		}
-		l--
-		top := it.s[l]
-		if len(top) == 0 {
-			it.s = it.s[:l]
-			down = true
-			continue
-		}
-		i := len(top) - 1
-		if down && i > 0 {
-			down = false
-			n := top[i]
-			it.s[l] = top[:i]
-			it.start(n)
-			continue
-		}
-		down = false
-		it.cur = top[i]
-		it.s[l] = top[:i]
-		return true
-	}
-}
-func (it *postOrderIter) Node() nodes.External {
-	return it.cur
-}
-
-type levelOrderIter struct {
-	level []nodes.External
-	i     int
-}
-
-func (it *levelOrderIter) Next() bool {
-	if len(it.level) == 0 {
-		return false
-	} else if it.i+1 < len(it.level) {
-		it.i++
-		return true
-	}
-	var next []nodes.External
-	for _, n := range it.level {
-		eachChild(n, func(v nodes.External) {
-			next = append(next, v)
-		})
-	}
-	it.i = 0
-	it.level = next
-	return len(it.level) > 0
-}
-func (it *levelOrderIter) Node() nodes.External {
-	if it.i >= len(it.level) {
-		return nil
-	}
-	return it.level[it.i]
+	return nodes.NewIterator(root, order)
 }

--- a/uast/query/query.go
+++ b/uast/query/query.go
@@ -16,12 +16,7 @@ type Query interface {
 	Execute(root nodes.External) (Iterator, error)
 }
 
-type Iterator interface {
-	// Next advances an iterator.
-	Next() bool
-	// Node returns a current node.
-	Node() nodes.External
-}
+type Iterator = nodes.Iterator
 
 // AllNodes iterates over all nodes and returns them as a slice.
 func AllNodes(it Iterator) []nodes.External {

--- a/uast/uast.go
+++ b/uast/uast.go
@@ -85,6 +85,36 @@ type Position struct {
 	Col uint32 `json:"col"`
 }
 
+func (p Position) HasOffset() bool {
+	return p.Offset != 0 || (p.Line == 1 && p.Col == 1)
+}
+
+func (p Position) HasLineCol() bool {
+	return p.Line != 0 && p.Col != 0
+}
+
+func (p Position) Valid() bool {
+	return p != (Position{})
+}
+
+func (p Position) Less(p2 Position) bool {
+	if !p.Valid() {
+		return false
+	} else if !p2.Valid() {
+		return true
+	}
+	if p.HasOffset() && p2.HasOffset() {
+		return p.Offset < p2.Offset
+	}
+	if p.Line != p2.Line {
+		if p.Line != 0 && p2.Line != 0 {
+			return p.Line < p2.Line
+		}
+		return p.Line != 0
+	}
+	return p.Col != 0 && p.Col < p2.Col
+}
+
 // Positions is a container object that stores all positional information for a node.
 type Positions map[string]Position
 


### PR DESCRIPTION
* move base iterators to nodes package

* implement ToNode, TypeOf and NodeAs in terms of external nodes

* implement positional iterator

Signed-off-by: Denys Smirnov <denys@sourced.tech>