### PR TITLE
Ignore Github rate limit errors in tests

### DIFF
--- a/driver/manifest/discovery/discovery.go
+++ b/driver/manifest/discovery/discovery.go
@@ -196,6 +196,12 @@ type Options struct {
 	NoMaintainers bool   // do not load maintainers list
 }
 
+// isRateLimit checks if error is due to rate limiting.
+func isRateLimit(err error) bool {
+	_, ok := err.(*github.RateLimitError)
+	return ok
+}
+
 // getDriversForOrg lists all repositories for an organization and filters ones that contains topics of the driver.
 func getDriversForOrg(ctx context.Context, org string) ([]Driver, error) {
 	cli := github.NewClient(nil)

--- a/driver/manifest/discovery/discovery_test.go
+++ b/driver/manifest/discovery/discovery_test.go
@@ -25,6 +25,9 @@ func TestOfficialDrivers(t *testing.T) {
 		t.SkipNow()
 	}
 	drivers, err := OfficialDrivers(context.Background(), nil)
+	if isRateLimit(err) {
+		t.Skip(err)
+	}
 	require.NoError(t, err)
 	require.True(t, len(drivers) >= 15, "drivers: %d", len(drivers))
 


### PR DESCRIPTION
Until we host a static manifest with the list of drivers, I propose to skip test failures if an error is due to rate limiting.

In any case, rate limiting affects 30-50% of our builds, thus the other 50-70% will be able to verify that the test passes (or not).

Signed-off-by: Denys Smirnov <denys@sourced.tech>