### PR TITLE
Detect SDK version of the driver

### DIFF
--- a/assets/skeleton/bindata.go
+++ b/assets/skeleton/bindata.go
@@ -845,14 +845,14 @@ func license() (*asset, error) {
 
 var _readmeMdTpl = []byte(`# {{.Manifest.Name}} driver for [Babelfish](https://github.com/bblfsh/bblfshd) ![Driver Status](https://img.shields.io/badge/status-{{.Manifest.Status | escape_shield}}-{{template "color-status" .}}.svg) [![Build Status](https://travis-ci.org/bblfsh/{{.Manifest.Language}}-driver.svg?branch=master)](https://travis-ci.org/bblfsh/{{.Manifest.Language | escape_shield }}-driver) ![Native Version](https://img.shields.io/badge/{{.Manifest.Language}}%20version-{{.Manifest.Runtime.NativeVersion | escape_shield}}-aa93ea.svg) ![Go Version](https://img.shields.io/badge/go%20version-{{.Manifest.Runtime.GoVersion | escape_shield}}-63afbf.svg)
 
-{{.Manifest.Documentation.Description}}
+{{if .Manifest.Documentation}}{{.Manifest.Documentation.Description}}
 
 {{if .Manifest.Documentation.Caveats -}}
 Caveats
 -------
 
 {{.Manifest.Documentation.Caveats}}
-{{end -}}
+{{end -}}{{end -}}
 
 
 Development Environment
@@ -906,7 +906,7 @@ func readmeMdTpl() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "README.md.tpl", size: 1892, mode: os.FileMode(420), modTime: time.Unix(1, 0)}
+	info := bindataFileInfo{name: "README.md.tpl", size: 1931, mode: os.FileMode(420), modTime: time.Unix(1, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }

--- a/cmd/bblfsh-sdk/cmd/info.go
+++ b/cmd/bblfsh-sdk/cmd/info.go
@@ -1,0 +1,26 @@
+package cmd
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+
+	"gopkg.in/bblfsh/sdk.v2/cmd"
+	"gopkg.in/bblfsh/sdk.v2/driver/manifest"
+)
+
+const InfoCommandDescription = "prints info about the driver"
+
+type InfoCommand struct {
+	cmd.Command
+}
+
+func (c *InfoCommand) Execute(args []string) error {
+	m, err := manifest.Load(filepath.Join(c.Root, manifestName))
+	if err != nil {
+		return err
+	}
+	enc := json.NewEncoder(os.Stdout)
+	enc.SetIndent("", "  ")
+	return enc.Encode(m)
+}

--- a/cmd/bblfsh-sdk/cmd/update.go
+++ b/cmd/bblfsh-sdk/cmd/update.go
@@ -19,7 +19,8 @@ import (
 
 const (
 	tplExtension = ".tpl"
-	manifestTpl  = "manifest.toml.tpl"
+	manifestName = "manifest.toml"
+	manifestTpl  = manifestName + ".tpl"
 )
 
 var overwriteManagedFiles = os.Getenv("BABELFISH_OVERWRITE_MANAGED") == "true"

--- a/cmd/bblfsh-sdk/main.go
+++ b/cmd/bblfsh-sdk/main.go
@@ -14,6 +14,7 @@ var build string
 
 func main() {
 	parser := flags.NewNamedParser("bblfsh-sdk", flags.Default)
+	parser.AddCommand("info", cmd.InfoCommandDescription, "", &cmd.InfoCommand{})
 	parser.AddCommand("update", cmd.UpdateCommandDescription, "", &cmd.UpdateCommand{})
 	parser.AddCommand("init", cmd.InitCommandDescription, "", &cmd.InitCommand{})
 	parser.AddCommand("build", cmd.BuildCommandDescription, "", &cmd.BuildCommand{})

--- a/driver/manifest/discovery/discovery_test.go
+++ b/driver/manifest/discovery/discovery_test.go
@@ -2,23 +2,11 @@ package discovery
 
 import (
 	"context"
-	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 	"gopkg.in/bblfsh/sdk.v2/driver/manifest"
 )
-
-func TestParseMaintainers(t *testing.T) {
-	m := parseMaintainers(strings.NewReader(`
-John Doe <john@domain.com> (@john_at_github)
-Bob <bob@domain.com>
-`))
-	require.Equal(t, []Maintainer{
-		{Name: "John Doe", Email: "john@domain.com", Github: "john_at_github"},
-		{Name: "Bob", Email: "bob@domain.com"},
-	}, m)
-}
 
 func TestOfficialDrivers(t *testing.T) {
 	if testing.Short() {

--- a/driver/manifest/manifest.go
+++ b/driver/manifest/manifest.go
@@ -1,13 +1,38 @@
 package manifest
 
 import (
+	"bufio"
+	"fmt"
 	"io"
 	"os"
+	"path/filepath"
+	"reflect"
+	"regexp"
+	"strconv"
 	"strings"
 	"time"
+	"unicode"
 
 	"github.com/BurntSushi/toml"
 )
+
+// CurrentSDKMajor returns a major version of this SDK package.
+func CurrentSDKMajor() int {
+	type dummy struct{}
+	p := reflect.TypeOf(dummy{}).PkgPath()
+	const pref = "/sdk.v"
+	i := strings.Index(p, pref)
+	p = p[i+len(pref):]
+	i = strings.Index(p, "/")
+	if i > 0 {
+		p = p[:i]
+	}
+	v, err := strconv.Atoi(p)
+	if err != nil {
+		panic(err)
+	}
+	return v
+}
 
 const Filename = "manifest.toml"
 
@@ -89,24 +114,28 @@ func (os OS) AsImage() string {
 	}
 }
 
+type Documentation struct {
+	Description string `toml:"description,omitempty" json:",omitempty"`
+	Caveats     string `toml:"caveats,omitempty" json:",omitempty"`
+}
+
 type Manifest struct {
 	Name            string            `toml:"name"` // human-readable name
 	Language        string            `toml:"language"`
-	Version         string            `toml:"version,omitempty"`
-	Build           *time.Time        `toml:"build,omitempty"`
+	Version         string            `toml:"version,omitempty" json:",omitempty"`
+	Build           *time.Time        `toml:"build,omitempty" json:",omitempty"`
 	Status          DevelopmentStatus `toml:"status"`
-	InformationLoss []InformationLoss `toml:"loss"`
-	Documentation   struct {
-		Description string `toml:"description,omitempty"`
-		Caveats     string `toml:"caveats,omitempty"`
-	} `toml:"documentation,omitempty"`
-	Runtime struct {
-		OS             OS       `toml:"os"`
-		NativeVersion  Versions `toml:"native_version"`
-		NativeEncoding string   `toml:"native_encoding"`
-		GoVersion      string   `toml:"go_version"`
+	InformationLoss []InformationLoss `toml:"loss" json:",omitempty"`
+	SDKVersion      string            `toml:"-"` // do not read it from manifest.toml
+	Documentation   *Documentation    `toml:"documentation,omitempty" json:",omitempty"`
+	Runtime         struct {
+		OS             OS       `toml:"os" json:",omitempty"`
+		NativeVersion  Versions `toml:"native_version" json:",omitempty"`
+		NativeEncoding string   `toml:"native_encoding" json:",omitempty"`
+		GoVersion      string   `toml:"go_version" json:",omitempty"`
 	} `toml:"runtime"`
-	Features []Feature `toml:"features"`
+	Features    []Feature    `toml:"features" json:",omitempty"`
+	Maintainers []Maintainer `toml:"-" json:",omitempty"`
 }
 
 // Supports checks if driver supports specified feature.
@@ -117,6 +146,37 @@ func (m Manifest) Supports(f Feature) bool {
 		}
 	}
 	return false
+}
+
+// SDKMajor returns a major version of SDK this driver was built for.
+func (m Manifest) SDKMajor() int {
+	vers := m.SDKVersion
+	if vers == "" {
+		return 0
+	}
+	if i := strings.Index(vers, "."); i >= 0 {
+		vers = vers[:i]
+	}
+	v, err := strconv.Atoi(vers)
+	if err != nil {
+		panic(err)
+	}
+	return v
+}
+
+// ForCurrentSDK indicates that driver is built for the same major version of SDK.
+func (m Manifest) ForCurrentSDK() bool {
+	return m.SDKMajor() == CurrentSDKMajor()
+}
+
+// InDevelopment indicates that driver is incomplete and should only be used for development purposes.
+func (m Manifest) InDevelopment() bool {
+	return m.Status.Rank() < Alpha.Rank()
+}
+
+// IsRecommended indicates that driver is stable enough to be used in production.
+func (m Manifest) IsRecommended() bool {
+	return m.ForCurrentSDK() && m.Status.Rank() >= Beta.Rank()
 }
 
 type Versions []string
@@ -133,7 +193,21 @@ func Load(path string) (*Manifest, error) {
 	}
 
 	m := &Manifest{}
-	return m, m.Decode(f)
+	if err := m.Decode(f); err != nil {
+		return m, err
+	}
+	dir := filepath.Dir(path)
+	open := InDir(dir)
+
+	m.SDKVersion, err = SDKVersion(open)
+	if err != nil {
+		return m, err
+	}
+	m.Maintainers, err = Maintainers(open)
+	if err != nil {
+		return m, err
+	}
+	return m, nil
 }
 
 // Encode encodes m in toml format and writes the restult to w
@@ -147,6 +221,153 @@ func (m *Manifest) Decode(r io.Reader) error {
 	if _, err := toml.DecodeReader(r, m); err != nil {
 		return err
 	}
-
 	return nil
+}
+
+// Maintainer is an information about project maintainer.
+type Maintainer struct {
+	Name   string `json:",omitempty"`
+	Email  string `json:",omitempty"`
+	Github string `json:",omitempty"` // github handle
+}
+
+// GithubURL returns github profile URL.
+func (m Maintainer) GithubURL() string {
+	if m.Github != "" {
+		return `https://github.com/` + m.Github
+	}
+	return ""
+}
+
+// URL returns a contact of the maintainer (either Github profile or email link).
+func (m Maintainer) URL() string {
+	if m.Github != "" {
+		return m.GithubURL()
+	} else if m.Email != "" {
+		return `mailto:` + m.Email
+	}
+	return ""
+}
+
+// OpenFunc is a function for fetching a file using a relative file path.
+// It returns an empty error an nil reader in case file does not exist.
+type OpenFunc func(path string) (io.ReadCloser, error)
+
+// InDir returns a function that read files in the specified directory.
+func InDir(dir string) OpenFunc {
+	return func(path string) (io.ReadCloser, error) {
+		if filepath.IsAbs(path) {
+			return nil, fmt.Errorf("expected relative path, got: %q", path)
+		}
+		f, err := os.Open(filepath.Join(dir, path))
+		if os.IsNotExist(err) {
+			return nil, nil
+		} else if err != nil {
+			return nil, err
+		}
+		return f, nil
+	}
+}
+
+var currentDir = InDir("")
+
+// reMaintainer is a regexp for one line of MAINTAINERS file (Github handle is optional):
+//
+//		John Doe <john@domain.com> (@john_at_github)
+var reMaintainer = regexp.MustCompile(`^([^<(]+)\s<([^>]+)>(\s\(@([^\s]+)\))?`)
+
+// parseMaintainers parses the MAINTAINERS file. It will ignore lines that does not match the reMaintainer regexp.
+func parseMaintainers(r io.Reader) []Maintainer {
+	var out []Maintainer
+	sc := bufio.NewScanner(r)
+	for sc.Scan() {
+		line := strings.TrimSpace(sc.Text())
+		sub := reMaintainer.FindStringSubmatch(line)
+		if len(sub) == 0 {
+			continue
+		}
+		m := Maintainer{Name: sub[1], Email: sub[2]}
+		if len(sub) >= 5 {
+			m.Github = sub[4]
+		}
+		out = append(out, m)
+	}
+	return out
+}
+
+// Maintainers reads and parses the MAINTAINERS file using the provided function.
+func Maintainers(open OpenFunc) ([]Maintainer, error) {
+	if open == nil {
+		open = currentDir
+	}
+	rc, err := open("MAINTAINERS")
+	if err != nil {
+		return nil, err
+	} else if rc == nil {
+		return nil, nil
+	}
+	defer rc.Close()
+
+	list := parseMaintainers(rc)
+	return list, nil
+}
+
+const sdkName = "gopkg.in/bblfsh/sdk"
+
+// maxVersionToml finds a maximal version of a Babelfish SDK in the list of the projects.
+func maxVersionToml(projs []map[string]interface{}) string {
+	max := ""
+	for _, p := range projs {
+		name, _ := p["name"].(string)
+		if !strings.HasPrefix(name, sdkName) {
+			continue
+		}
+		vers, _ := p["version"].(string)
+		vers = strings.TrimPrefix(vers, "v")
+		vers = strings.TrimRight(vers, ".x")
+		if vers == "" || !unicode.IsDigit(rune(vers[0])) {
+			vers = strings.TrimPrefix(name, sdkName+".v")
+			if max < vers {
+				max = vers
+			}
+			continue
+		}
+		if max < vers {
+			max = vers
+		}
+	}
+	return max
+}
+
+// SDKVersion detects a Babelfish SDK version of a driver. Returned format is "x[.y[.z]]".
+func SDKVersion(open OpenFunc) (string, error) {
+	if f, err := open("Gopkg.lock"); err == nil && f != nil {
+		defer f.Close()
+
+		var m map[string]interface{}
+		_, err := toml.DecodeReader(f, &m)
+		if err != nil {
+			return "", err
+		}
+		projs, _ := m["projects"].([]map[string]interface{})
+		max := maxVersionToml(projs)
+		if max != "" {
+			return max, nil
+		}
+	}
+	if f, err := open("Gopkg.toml"); err == nil && f != nil {
+		defer f.Close()
+
+		var m map[string]interface{}
+		_, err := toml.DecodeReader(f, &m)
+		if err != nil {
+			return "", err
+		}
+		projs, _ := m["constraint"].([]map[string]interface{})
+		max := maxVersionToml(projs)
+		if max != "" {
+			return max, nil
+		}
+	}
+	return "1", nil
 }

--- a/driver/manifest/manifest_test.go
+++ b/driver/manifest/manifest_test.go
@@ -2,9 +2,13 @@ package manifest
 
 import (
 	"bytes"
+	"io"
+	"io/ioutil"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 var fixture = `
@@ -28,7 +32,9 @@ func TestEncode(t *testing.T) {
 	m.Name = "Foo"
 	m.Language = "foo"
 	m.Features = []Feature{AST, UAST, Roles}
-	m.Documentation.Description = "foo"
+	m.Documentation = &Documentation{
+		Description: "foo",
+	}
 	m.Runtime.OS = Alpine
 	m.Runtime.GoVersion = "1.9"
 	m.Runtime.NativeVersion = []string{"42"}
@@ -50,4 +56,97 @@ func TestDecode(t *testing.T) {
 
 	assert.Equal(t, "foo", m.Language)
 	assert.Equal(t, Alpine, m.Runtime.OS)
+}
+
+func TestCurrentSDKVersion(t *testing.T) {
+	require.Equal(t, 2, CurrentSDKMajor())
+}
+
+func TestParseMaintainers(t *testing.T) {
+	m := parseMaintainers(strings.NewReader(`
+John Doe <john@domain.com> (@john_at_github)
+Bob <bob@domain.com>
+`))
+	require.Equal(t, []Maintainer{
+		{Name: "John Doe", Email: "john@domain.com", Github: "john_at_github"},
+		{Name: "Bob", Email: "bob@domain.com"},
+	}, m)
+}
+
+var casesVersion = []struct {
+	name   string
+	files  map[string]string
+	expect string
+}{
+	{
+		name:   "no files",
+		expect: "1",
+	},
+	{
+		name: "dep lock v1",
+		files: map[string]string{
+			"Gopkg.lock": `
+[[projects]]
+  name = "gopkg.in/bblfsh/sdk.v1"
+  version = "v1.16.1"
+`,
+		},
+		expect: "1.16.1",
+	},
+	{
+		name: "dep lock both",
+		files: map[string]string{
+			"Gopkg.lock": `
+[[projects]]
+  name = "gopkg.in/bblfsh/sdk.v1"
+  version = "v1.16.1"
+
+[[projects]]
+  name = "gopkg.in/bblfsh/sdk.v2"
+  version = "v2.2.1"
+`,
+		},
+		expect: "2.2.1",
+	},
+	{
+		name: "dep lock no vers",
+		files: map[string]string{
+			"Gopkg.lock": `
+[[projects]]
+  name = "gopkg.in/bblfsh/sdk.v1"
+
+[[projects]]
+  name = "gopkg.in/bblfsh/sdk.v2"
+`,
+		},
+		expect: "2",
+	},
+	{
+		name: "dep toml x",
+		files: map[string]string{
+			"Gopkg.toml": `
+[[constraint]]
+  name = "gopkg.in/bblfsh/sdk.v1"
+  version = "1.16.x"
+`,
+		},
+		expect: "1.16",
+	},
+}
+
+func TestSDKVersion(t *testing.T) {
+	for _, c := range casesVersion {
+		c := c
+		t.Run(c.name, func(t *testing.T) {
+			vers, err := SDKVersion(func(path string) (io.ReadCloser, error) {
+				data, ok := c.files[path]
+				if !ok {
+					return nil, nil
+				}
+				return ioutil.NopCloser(strings.NewReader(data)), nil
+			})
+			require.NoError(t, err)
+			require.Equal(t, c.expect, vers)
+		})
+	}
 }

--- a/etc/skeleton/README.md.tpl
+++ b/etc/skeleton/README.md.tpl
@@ -1,13 +1,13 @@
 # {{.Manifest.Name}} driver for [Babelfish](https://github.com/bblfsh/bblfshd) ![Driver Status](https://img.shields.io/badge/status-{{.Manifest.Status | escape_shield}}-{{template "color-status" .}}.svg) [![Build Status](https://travis-ci.org/bblfsh/{{.Manifest.Language}}-driver.svg?branch=master)](https://travis-ci.org/bblfsh/{{.Manifest.Language | escape_shield }}-driver) ![Native Version](https://img.shields.io/badge/{{.Manifest.Language}}%20version-{{.Manifest.Runtime.NativeVersion | escape_shield}}-aa93ea.svg) ![Go Version](https://img.shields.io/badge/go%20version-{{.Manifest.Runtime.GoVersion | escape_shield}}-63afbf.svg)
 
-{{.Manifest.Documentation.Description}}
+{{if .Manifest.Documentation}}{{.Manifest.Documentation.Description}}
 
 {{if .Manifest.Documentation.Caveats -}}
 Caveats
 -------
 
 {{.Manifest.Documentation.Caveats}}
-{{end -}}
+{{end -}}{{end -}}
 
 
 Development Environment


### PR DESCRIPTION
* Detect SDK version the driver was built for (use `dep` lock, or assume `v1`).
* Move the code that reads other manifests from `discovery` package to `manifest`.
* Add `bblfsh-sdk info` command.

Addresses https://github.com/bblfsh/sdk/issues/235

Signed-off-by: Denys Smirnov <denys@sourced.tech>