### PR TITLE
Define and propagate driver error codes

### DIFF
--- a/build/dev.go
+++ b/build/dev.go
@@ -64,7 +64,7 @@ func (d *ServerInstance) ClientV1(ctx context.Context) (protocol1.ProtocolServic
 	}
 	return protocol1.NewProtocolServiceClient(d.user), nil
 }
-func (d *ServerInstance) ClientV2(ctx context.Context, lang string) (driver.Driver, error) {
+func (d *ServerInstance) ClientV2(ctx context.Context) (driver.Driver, error) {
 	if d.user == nil {
 		addr := d.bblfshd.NetworkSettings.IPAddress
 		conn, err := grpc.DialContext(ctx, addr+":"+cliPort, grpc.WithInsecure(), grpc.WithBlock())
@@ -73,7 +73,7 @@ func (d *ServerInstance) ClientV2(ctx context.Context, lang string) (driver.Driv
 		}
 		d.user = conn
 	}
-	return protocol.AsDriver(d.user, lang), nil
+	return protocol.AsDriver(d.user), nil
 }
 func (s *ServerInstance) DumpLogs(w io.Writer) error {
 	return getLogs(s.cli, s.bblfshd.ID, w)

--- a/build/test.go
+++ b/build/test.go
@@ -139,7 +139,7 @@ func (d *Driver) testIntegration(bblfshdVers, image string) error {
 	if err != nil {
 		return err
 	}
-	cli2, err := srv.ClientV2(ctx, lang)
+	cli2, err := srv.ClientV2(ctx)
 	if err != nil {
 		return err
 	}
@@ -183,7 +183,10 @@ func (d *Driver) testIntegration(bblfshdVers, image string) error {
 		}
 
 		// test v2 protocol
-		ast, err := cli2.Parse(ctx, driver.ModeSemantic, content)
+		ast, err := cli2.Parse(ctx, content, &driver.ParseOptions{
+			Mode:     driver.ModeSemantic,
+			Language: lang,
+		})
 		if err != nil {
 			srv.DumpLogs(os.Stderr)
 			return err

--- a/cmd/bblfsh-sdk/cmd/fixtures.go
+++ b/cmd/bblfsh-sdk/cmd/fixtures.go
@@ -11,6 +11,7 @@ import (
 	protocol1 "gopkg.in/bblfsh/sdk.v1/protocol"
 	protocol2 "gopkg.in/bblfsh/sdk.v2/protocol"
 
+	derrors "gopkg.in/bblfsh/sdk.v2/driver/errors"
 	"gopkg.in/bblfsh/sdk.v2/uast/nodes"
 	"gopkg.in/bblfsh/sdk.v2/uast/yaml"
 )
@@ -123,11 +124,13 @@ func (c *FixturesCommand) getUast(source, filename string, mode protocol2.Mode) 
 	}
 
 	ast, err := res.Nodes()
-	if err != nil {
+	if derrors.ErrSyntax.Is(err) {
 		if !c.Quiet {
 			fmt.Println("Warning: parsing native AST for ", filename, "returned errors:")
 			fmt.Println(err)
 		}
+	} else if err != nil {
+		return nil, err
 	}
 
 	return ast, nil

--- a/driver/driver.go
+++ b/driver/driver.go
@@ -75,6 +75,9 @@ type ParseOptions struct {
 type Driver interface {
 	// Parse reads the input string and constructs an AST representation of it.
 	//
+	// Language can be specified by providing ParseOptions. If the language is not set,
+	// it will be set during the Parse call if implementation supports language detection.
+	//
 	// Depending on the mode, AST may be transformed to different UAST variants.
 	// ErrModeNotSupported is returned for unsupported transformation modes.
 	//

--- a/driver/driver.go
+++ b/driver/driver.go
@@ -65,6 +65,12 @@ type Module interface {
 	Close() error
 }
 
+type ParseOptions struct {
+	Mode     Mode
+	Language string
+	Filename string
+}
+
 // Driver is an interface for a language driver that returns UAST.
 type Driver interface {
 	// Parse reads the input string and constructs an AST representation of it.
@@ -77,7 +83,7 @@ type Driver interface {
 	//
 	// Native driver failures are indicated by ErrDriverFailure and UAST transformation are indicated by ErrTransformFailure.
 	// All other errors indicate a protocol or server failure.
-	Parse(ctx context.Context, mode Mode, src string) (nodes.Node, error)
+	Parse(ctx context.Context, src string, opts *ParseOptions) (nodes.Node, error)
 }
 
 // DriverModule is an interface for a driver instance.

--- a/driver/driver.go
+++ b/driver/driver.go
@@ -2,13 +2,38 @@
 package driver
 
 import (
-	"bytes"
 	"context"
 	"fmt"
 
+	"gopkg.in/src-d/go-errors.v1"
+
+	derrors "gopkg.in/bblfsh/sdk.v2/driver/errors"
 	"gopkg.in/bblfsh/sdk.v2/driver/manifest"
 	"gopkg.in/bblfsh/sdk.v2/uast/nodes"
 )
+
+var (
+	// ErrDriverFailure is returned when the driver is malfunctioning.
+	ErrDriverFailure = derrors.ErrDriverFailure
+
+	// ErrSyntax is returned when driver cannot parse the source file.
+	// Can be omitted for native driver implementations.
+	ErrSyntax = derrors.ErrSyntax
+
+	// ErrTransformFailure is returned if one of the UAST transformations fails.
+	ErrTransformFailure = errors.NewKind("transform failed")
+
+	// ErrModeNotSupported is returned if a UAST transformation mode is not supported by the driver.
+	ErrModeNotSupported = errors.NewKind("transform mode not supported")
+)
+
+// ErrMulti joins multiple errors.
+type ErrMulti = derrors.ErrMulti
+
+// Join multiple errors into a single error value.
+func JoinErrors(errs []error) error {
+	return derrors.Join(errs)
+}
 
 type Mode int
 
@@ -42,6 +67,16 @@ type Module interface {
 
 // Driver is an interface for a language driver that returns UAST.
 type Driver interface {
+	// Parse reads the input string and constructs an AST representation of it.
+	//
+	// Depending on the mode, AST may be transformed to different UAST variants.
+	// ErrModeNotSupported is returned for unsupported transformation modes.
+	//
+	// Syntax errors are indicated by returning ErrSyntax.
+	// In this case a non-empty UAST may be returned, if driver supports partial parsing.
+	//
+	// Native driver failures are indicated by ErrDriverFailure and UAST transformation are indicated by ErrTransformFailure.
+	// All other errors indicate a protocol or server failure.
 	Parse(ctx context.Context, mode Mode, src string) (nodes.Node, error)
 }
 
@@ -55,40 +90,7 @@ type DriverModule interface {
 // Native is a base interface of a language driver that returns a native AST.
 type Native interface {
 	Module
+	// Parse reads the input string and constructs an AST representation of it.
+	// All errors are considered ErrSyntax, unless they are wrapped into ErrDriverFailure.
 	Parse(ctx context.Context, src string) (nodes.Node, error)
-}
-
-// ErrMulti joins multiple errors.
-type ErrMulti struct {
-	Header string
-	Errors []string
-}
-
-func (e ErrMulti) Error() string {
-	buf := bytes.NewBuffer(nil)
-	if e.Header != "" {
-		buf.WriteString(e.Header + ":\n")
-	}
-	for _, s := range e.Errors {
-		buf.WriteString(s)
-		buf.WriteString("\n")
-	}
-	return buf.String()
-}
-
-func MultiError(errs []string) error {
-	return &ErrMulti{Errors: errs}
-}
-
-func PartialParse(ast nodes.Node, errs []string) error {
-	return &ErrPartialParse{
-		ErrMulti: ErrMulti{Header: "partial parse", Errors: errs},
-		AST:      ast,
-	}
-}
-
-// ErrPartialParse is returned when driver was not able to parse the whole source file.
-type ErrPartialParse struct {
-	ErrMulti
-	AST nodes.Node
 }

--- a/driver/errors/errors.go
+++ b/driver/errors/errors.go
@@ -1,0 +1,40 @@
+package errors
+
+import (
+	"strings"
+
+	"gopkg.in/src-d/go-errors.v1"
+)
+
+var (
+	// ErrDriverFailure is returned when the driver is malfunctioning.
+	ErrDriverFailure = errors.NewKind("driver failure")
+
+	// ErrSyntax is returned when driver cannot parse the source file.
+	// Can be omitted for native driver implementations.
+	ErrSyntax = errors.NewKind("syntax error")
+)
+
+// Join multiple errors into a single error value.
+// If there are only one error, it will be returned directly.
+// Zero or more than one error will be wrapped into ErrMulti.
+func Join(errs []error) error {
+	if len(errs) == 1 {
+		return errs[0]
+	}
+	return &ErrMulti{Errors: errs}
+}
+
+// ErrMulti joins multiple errors.
+type ErrMulti struct {
+	Errors []error
+}
+
+func (e *ErrMulti) Error() string {
+	var buf strings.Builder
+	for _, err := range e.Errors {
+		buf.WriteString(err.Error())
+		buf.WriteString("\n")
+	}
+	return buf.String()
+}

--- a/driver/impl.go
+++ b/driver/impl.go
@@ -43,7 +43,10 @@ func (d *driverImpl) Close() error {
 // Parse process a protocol.ParseRequest, calling to the native driver. It a
 // parser request is done to the internal native driver and the the returned
 // native AST is transform to UAST.
-func (d *driverImpl) Parse(ctx context.Context, mode Mode, src string) (nodes.Node, error) {
+func (d *driverImpl) Parse(ctx context.Context, src string, opts *ParseOptions) (nodes.Node, error) {
+	if opts == nil {
+		opts = &ParseOptions{}
+	}
 	ast, err := d.d.Parse(ctx, src)
 	if err != nil {
 		if !ErrDriverFailure.Is(err) {
@@ -54,7 +57,7 @@ func (d *driverImpl) Parse(ctx context.Context, mode Mode, src string) (nodes.No
 		}
 		return ast, err
 	}
-	ast, err = d.t.Do(mode, src, ast)
+	ast, err = d.t.Do(opts.Mode, src, ast)
 	if err != nil {
 		err = ErrTransformFailure.Wrap(err)
 	}

--- a/driver/impl.go
+++ b/driver/impl.go
@@ -57,6 +57,9 @@ func (d *driverImpl) Parse(ctx context.Context, src string, opts *ParseOptions) 
 		}
 		return ast, err
 	}
+	if opts.Language == "" {
+		opts.Language = d.m.Language
+	}
 	ast, err = d.t.Do(opts.Mode, src, ast)
 	if err != nil {
 		err = ErrTransformFailure.Wrap(err)

--- a/driver/native/native_test.go
+++ b/driver/native/native_test.go
@@ -1,12 +1,13 @@
 package native
 
 import (
+	"context"
 	"sync"
 	"testing"
 
-	"context"
-
 	"github.com/stretchr/testify/require"
+
+	derrors "gopkg.in/bblfsh/sdk.v2/driver/errors"
 )
 
 func TestEncoding(t *testing.T) {
@@ -103,6 +104,7 @@ func TestNativeDriverNativeParse_Malfunctioning(t *testing.T) {
 
 	_, err = d.Parse(context.Background(), "foo")
 	require.NotNil(err)
+	require.True(derrors.ErrDriverFailure.Is(err))
 }
 
 func TestNativeDriverNativeParse_Malformed(t *testing.T) {
@@ -115,4 +117,5 @@ func TestNativeDriverNativeParse_Malformed(t *testing.T) {
 
 	_, err = d.Parse(context.Background(), "foo")
 	require.NotNil(err)
+	require.True(derrors.ErrDriverFailure.Is(err))
 }

--- a/driver/server/grpc.go
+++ b/driver/server/grpc.go
@@ -107,7 +107,11 @@ func (s service) parse(mode driver.Mode, req *protocol1.ParseRequest) (nodes.Nod
 		ctx, cancel = context.WithTimeout(ctx, req.Timeout)
 		defer cancel()
 	}
-	ast, err := s.d.Parse(ctx, mode, req.Content)
+	ast, err := s.d.Parse(ctx, req.Content, &driver.ParseOptions{
+		Mode:     mode,
+		Language: req.Language,
+		Filename: req.Filename,
+	})
 	dt := time.Since(start)
 	var r protocol1.Response
 	if err != nil {

--- a/driver/transforms.go
+++ b/driver/transforms.go
@@ -26,6 +26,9 @@ type Transforms struct {
 
 // Do applies AST transformation pipeline for specified nodes.
 func (t Transforms) Do(mode Mode, code string, nd nodes.Node) (nodes.Node, error) {
+	if mode > ModeSemantic {
+		return nil, ErrModeNotSupported.New()
+	}
 	if mode == 0 {
 		mode = ModeDefault
 	}


### PR DESCRIPTION
Define common errors for native drivers and propagate them properly via gRPC boundary.

The list of errors so far:

- Syntax error (`ErrSyntax`): either partial or no UAST is returned. In gRPC, the status is `OK`, but an `Errors` field of the response contains error descriptions. 

- Native driver failure (`ErrDriverFailure`): native driver crashed or the native protocol connection is broken.  This indicates a bug in the driver and should be reported. Unrecoverable when returned by the driver. Driver server (either Go or `bblfshd`) should attempt a native driver restart before returning this error to the client.

- Transformation failed (`ErrTransformFailure`): parsing was succesful, but transformation pipeline for selected `Mode` fails to process it. This indicates a bug in the driver and should be reported. Recoverable, assuming `Mode` parameter is changed.

- All other errors are considered protocol/server failures.

Related:
- https://github.com/bblfsh/sdk/issues/257
- https://github.com/bblfsh/client-go/issues/82
