### PR TITLE
Update CI files

### DIFF
--- a/assets/skeleton/bindata.go
+++ b/assets/skeleton/bindata.go
@@ -87,9 +87,9 @@ services:
   - docker
 
 env:
-  - BBLFSHD_VERSION=v2.6.1
+  - BBLFSHD_VERSION=v2.9.1
 
-before_script:
+install:
   - curl -L https://github.com/golang/dep/releases/download/v0.4.1/dep-linux-amd64 > $GOPATH/bin/dep
   - chmod +x $GOPATH/bin/dep
   - dep ensure --vendor-only
@@ -116,7 +116,7 @@ func TravisYml() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: ".travis.yml", size: 585, mode: os.FileMode(420), modTime: time.Unix(1, 0)}
+	info := bindataFileInfo{name: ".travis.yml", size: 579, mode: os.FileMode(420), modTime: time.Unix(1, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }

--- a/etc/skeleton/.travis.yml
+++ b/etc/skeleton/.travis.yml
@@ -7,9 +7,9 @@ services:
   - docker
 
 env:
-  - BBLFSHD_VERSION=v2.6.1
+  - BBLFSHD_VERSION=v2.9.1
 
-before_script:
+install:
   - curl -L https://github.com/golang/dep/releases/download/v0.4.1/dep-linux-amd64 > $GOPATH/bin/dep
   - chmod +x $GOPATH/bin/dep
   - dep ensure --vendor-only


### PR DESCRIPTION
Override `install` step in Travis so that it doesn't execute `go get` automatically.
Also, update a bblfshd version.

Signed-off-by: Denys Smirnov <denys@sourced.tech>