### PR TITLE
Shared gRPC server config between bblfshd/driver

### DIFF
--- a/cmd/util.go
+++ b/cmd/util.go
@@ -16,33 +16,29 @@ const (
 	maxMsgSizeCLIDesc = "max. message size to send/receive to/from clients (in MB)"
 
 	// DefaulGRPCMaxSendRecvMsgSizeMB is maximum msg size for gRPC in MB.
-	DefaulGRPCMaxSendRecvMsgSizeMB = 100
+	defaulGRPCMaxSendRecvMsgSizeMB = 100
 	maxMsgSizeCapMB                = 2048
 )
 
 // GRPCSizeOptions returns a slice of gRPC server options with the max
 // message size the server can send/receive set.
-// If a >2GB value is requested: the maximum size limit is capped
-// at 100 MB and an error is returned.
+// Error is returned if requested size is bigger than 2GB.
 // It is intended to be shared by gRPC in bblfshd Server and Drivers.
-func GRPCSizeOptions(maxMessageSizeMB int) ([]grpc.ServerOption, error) {
-	var err error
-	sizeMB := maxMessageSizeMB
+func GRPCSizeOptions(sizeMB int) ([]grpc.ServerOption, error) {
 	if sizeMB >= maxMsgSizeCapMB || sizeMB <= 0 {
-		err = fmt.Errorf("%s=%d is too big (limit is %dMB), using %d instead",
-			maxMsgSizeCLIName, sizeMB, maxMsgSizeCapMB-1, DefaulGRPCMaxSendRecvMsgSizeMB)
-		sizeMB = DefaulGRPCMaxSendRecvMsgSizeMB
+		return nil, fmt.Errorf("%s=%d value should be in between 1 and %dMB",
+			maxMsgSizeCLIName, sizeMB, maxMsgSizeCapMB-1)
 	}
 
 	sizeBytes := sizeMB * 1024 * 1024
 	return []grpc.ServerOption{
 		grpc.MaxRecvMsgSize(sizeBytes),
 		grpc.MaxSendMsgSize(sizeBytes),
-	}, err
+	}, nil
 }
 
-// MaxSendRecvMsgSizeMB sets the CLI configuation flag for max
+// FlagMaxGRPCMsgSizeMB sets the CLI configuation flag for max
 // gRPC send/recive msg size.
-func MaxSendRecvMsgSizeMB(fs *flag.FlagSet) *int {
-	return fs.Int(maxMsgSizeCLIName, DefaulGRPCMaxSendRecvMsgSizeMB, maxMsgSizeCLIDesc)
+func FlagMaxGRPCMsgSizeMB(fs *flag.FlagSet) *int {
+	return fs.Int(maxMsgSizeCLIName, defaulGRPCMaxSendRecvMsgSizeMB, maxMsgSizeCLIDesc)
 }

--- a/cmd/util.go
+++ b/cmd/util.go
@@ -1,0 +1,48 @@
+package cmd
+
+// Contains CLI helpers, shared between bblfshd and drivers.
+
+import (
+	"flag"
+	"fmt"
+
+	"google.golang.org/grpc"
+)
+
+const (
+	// MaxMsgSizeCLIName is name of the CLI flag to set max msg size.
+	maxMsgSizeCLIName = "grpc-max-message-size"
+	// MaxMsgSizeCLIDesc is description for the CLI flag to set max msg size.
+	maxMsgSizeCLIDesc = "max. message size to send/receive to/from clients (in MB)"
+
+	// DefaulGRPCMaxSendRecvMsgSizeMB is maximum msg size for gRPC in MB.
+	DefaulGRPCMaxSendRecvMsgSizeMB = 100
+	maxMsgSizeCapMB                = 2048
+)
+
+// GRPCSizeOptions returns a slice of gRPC server options with the max
+// message size the server can send/receive set.
+// If a >2GB value is requested: the maximum size limit is capped
+// at 100 MB and an error is returned.
+// It is intended to be shared by gRPC in bblfshd Server and Drivers.
+func GRPCSizeOptions(maxMessageSizeMB int) ([]grpc.ServerOption, error) {
+	var err error
+	sizeMB := maxMessageSizeMB
+	if sizeMB >= maxMsgSizeCapMB || sizeMB <= 0 {
+		err = fmt.Errorf("%s=%d is too big (limit is %dMB), using %d instead",
+			maxMsgSizeCLIName, sizeMB, maxMsgSizeCapMB-1, DefaulGRPCMaxSendRecvMsgSizeMB)
+		sizeMB = DefaulGRPCMaxSendRecvMsgSizeMB
+	}
+
+	sizeBytes := sizeMB * 1024 * 1024
+	return []grpc.ServerOption{
+		grpc.MaxRecvMsgSize(sizeBytes),
+		grpc.MaxSendMsgSize(sizeBytes),
+	}, err
+}
+
+// MaxSendRecvMsgSizeMB sets the CLI configuation flag for max
+// gRPC send/recive msg size.
+func MaxSendRecvMsgSizeMB(fs *flag.FlagSet) *int {
+	return fs.Int(maxMsgSizeCLIName, DefaulGRPCMaxSendRecvMsgSizeMB, maxMsgSizeCLIDesc)
+}

--- a/cmd/util_test.go
+++ b/cmd/util_test.go
@@ -1,0 +1,25 @@
+package cmd
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestGRPCOptions_InvalidInput(t *testing.T) {
+	opts, err := GRPCSizeOptions(-1)
+
+	require.Error(t, err, "a given value was not applied")
+	require.NotNil(t, opts)
+	require.Len(t, opts, 2)
+	// does not work as expected for Func values like grpc.ServerOption
+	//require.Contains(t, opts, grpc.MaxRecvMsgSize(DefaulGRPCMaxSendRecvMsgSizeMB))
+	//require.Contains(t, opts, grpc.MaxSendMsgSize(DefaulGRPCMaxSendRecvMsgSizeMB))
+}
+
+func TestGRPCOptions_ValidInput(t *testing.T) {
+	opts, err := GRPCSizeOptions(32)
+
+	require.Nil(t, err)
+	require.NotNil(t, opts)
+}

--- a/cmd/util_test.go
+++ b/cmd/util_test.go
@@ -7,14 +7,15 @@ import (
 )
 
 func TestGRPCOptions_InvalidInput(t *testing.T) {
+	// too small
 	opts, err := GRPCSizeOptions(-1)
+	require.Error(t, err, "a small value should not be applied")
+	require.Nil(t, opts)
 
-	require.Error(t, err, "a given value was not applied")
-	require.NotNil(t, opts)
-	require.Len(t, opts, 2)
-	// does not work as expected for Func values like grpc.ServerOption
-	//require.Contains(t, opts, grpc.MaxRecvMsgSize(DefaulGRPCMaxSendRecvMsgSizeMB))
-	//require.Contains(t, opts, grpc.MaxSendMsgSize(DefaulGRPCMaxSendRecvMsgSizeMB))
+	// too big
+	opts, err = GRPCSizeOptions(maxMsgSizeCapMB + 1)
+	require.Error(t, err, "a big value should not be applied")
+	require.Nil(t, opts)
 }
 
 func TestGRPCOptions_ValidInput(t *testing.T) {
@@ -22,4 +23,8 @@ func TestGRPCOptions_ValidInput(t *testing.T) {
 
 	require.Nil(t, err)
 	require.NotNil(t, opts)
+	require.Len(t, opts, 2)
+	// does not work as expected for Func values like grpc.ServerOption
+	//require.Contains(t, opts, grpc.MaxRecvMsgSize(DefaulGRPCMaxSendRecvMsgSizeMB))
+	//require.Contains(t, opts, grpc.MaxSendMsgSize(DefaulGRPCMaxSendRecvMsgSizeMB))
 }

--- a/common.go
+++ b/common.go
@@ -15,29 +15,28 @@ const (
 	// MaxMsgSizeCLIDesc is description for the CLI flag to set max msg size.
 	MaxMsgSizeCLIDesc = "max. message size to send/receive to/from clients (in MB)"
 
-	// DefaulGRPCMaxMsgSizeMb is maximum msg size for gRPC in Mb.
-	DefaulGRPCMaxMsgSizeMb = 100
-	gRPCMaxMsgSizeCapMb    = 2048
+	// DefaulGRPCMaxSendRecvMsgSizeMB is maximum msg size for gRPC in MB.
+	DefaulGRPCMaxSendRecvMsgSizeMB = 100
+	maxMsgSizeCapMB                = 2048
 )
 
-// GRPCOptions returns a slice of gRPC server options with the maximum
-// message size set for sending and receiving.
-// Is intended to be shared by gRPC in bblfshd Server and Drivers.
-// Sets the hard limit of message size to less than 2GB since
-// it may overflow an int value, and it should be big enough.
-func GRPCOptions(maxMessageSizeMb int) ([]grpc.ServerOption, error) {
+// GRPCOptions returns a slice of gRPC server options with the max
+// message size the server can send/receive set.
+// If a >2GB value is requested: the maximum size limit is capped
+// at 100 MB and an error is returned.
+// It is intended to be shared by gRPC in bblfshd Server and Drivers.
+func GRPCOptions(maxMessageSizeMB int) ([]grpc.ServerOption, error) {
 	var err error
-	size := maxMessageSizeMb
-	if size >= gRPCMaxMsgSizeCapMb {
+	sizeMB := maxMessageSizeMB
+	if sizeMB >= maxMsgSizeCapMB {
 		err = fmt.Errorf("%s=%d is too big (limit is %dMB), using %d instead",
-			MaxMsgSizeCLIName, size, gRPCMaxMsgSizeCapMb-1, DefaulGRPCMaxMsgSizeMb)
-		size = DefaulGRPCMaxMsgSizeMb
+			MaxMsgSizeCLIName, sizeMB, maxMsgSizeCapMB-1, DefaulGRPCMaxSendRecvMsgSizeMB)
+		sizeMB = DefaulGRPCMaxSendRecvMsgSizeMB
 	}
 
-	size = size * 1024 * 1024
-
+	sizeBytes := sizeMB * 1024 * 1024
 	return []grpc.ServerOption{
-		grpc.MaxRecvMsgSize(size),
-		grpc.MaxSendMsgSize(size),
+		grpc.MaxRecvMsgSize(sizeBytes),
+		grpc.MaxSendMsgSize(sizeBytes),
 	}, err
 }

--- a/common.go
+++ b/common.go
@@ -20,11 +20,12 @@ const (
 	gRPCMaxMsgSizeCapMb    = 2048
 )
 
-//BuildGRPCOptions creats gRPC ServerOption \w maxRecv/Send msg size set.
+// GRPCOptions returns a slice of gRPC server options with the maximum
+// message size set for sending and receiving.
 // Is intended to be shared by gRPC in bblfshd Server and Drivers.
 // Sets the hard limit of message size to less than 2GB since
 // it may overflow an int value, and it should be big enough.
-func BuildGRPCOptions(maxMessageSizeMb int) ([]grpc.ServerOption, error) {
+func GRPCOptions(maxMessageSizeMb int) ([]grpc.ServerOption, error) {
 	var err error
 	size := maxMessageSizeMb
 	if size >= gRPCMaxMsgSizeCapMb {

--- a/common.go
+++ b/common.go
@@ -1,4 +1,42 @@
 package sdk
 
+import (
+	"fmt"
+
+	"google.golang.org/grpc"
+)
+
 const NativeBin = "/opt/driver/bin/native"
 const NativeBinTest = "/opt/driver/src/build/native"
+
+const (
+	// MaxMsgSizeCLIName is name of the CLI flag to set max msg size.
+	MaxMsgSizeCLIName = "grpc-max-message-size"
+	// MaxMsgSizeCLIDesc is description for the CLI flag to set max msg size.
+	MaxMsgSizeCLIDesc = "max. message size to send/receive to/from clients (in MB)"
+
+	// DefaulGRPCMaxMsgSizeMb is maximum msg size for gRPC in Mb.
+	DefaulGRPCMaxMsgSizeMb = 100
+	gRPCMaxMsgSizeCapMb    = 2048
+)
+
+//BuildGRPCOptions creats gRPC ServerOption \w maxRecv/Send msg size set.
+// Is intended to be shared by gRPC in bblfshd Server and Drivers.
+// Sets the hard limit of message size to less than 2GB since
+// it may overflow an int value, and it should be big enough.
+func BuildGRPCOptions(maxMessageSizeMb int) ([]grpc.ServerOption, error) {
+	var err error
+	size := maxMessageSizeMb
+	if size >= gRPCMaxMsgSizeCapMb {
+		err = fmt.Errorf("%s=%d is too big (limit is %dMB), using %d instead",
+			MaxMsgSizeCLIName, size, gRPCMaxMsgSizeCapMb-1, DefaulGRPCMaxMsgSizeMb)
+		size = DefaulGRPCMaxMsgSizeMb
+	}
+
+	size = size * 1024 * 1024
+
+	return []grpc.ServerOption{
+		grpc.MaxRecvMsgSize(size),
+		grpc.MaxSendMsgSize(size),
+	}, err
+}

--- a/common.go
+++ b/common.go
@@ -1,42 +1,4 @@
 package sdk
 
-import (
-	"fmt"
-
-	"google.golang.org/grpc"
-)
-
 const NativeBin = "/opt/driver/bin/native"
 const NativeBinTest = "/opt/driver/src/build/native"
-
-const (
-	// MaxMsgSizeCLIName is name of the CLI flag to set max msg size.
-	MaxMsgSizeCLIName = "grpc-max-message-size"
-	// MaxMsgSizeCLIDesc is description for the CLI flag to set max msg size.
-	MaxMsgSizeCLIDesc = "max. message size to send/receive to/from clients (in MB)"
-
-	// DefaulGRPCMaxSendRecvMsgSizeMB is maximum msg size for gRPC in MB.
-	DefaulGRPCMaxSendRecvMsgSizeMB = 100
-	maxMsgSizeCapMB                = 2048
-)
-
-// GRPCOptions returns a slice of gRPC server options with the max
-// message size the server can send/receive set.
-// If a >2GB value is requested: the maximum size limit is capped
-// at 100 MB and an error is returned.
-// It is intended to be shared by gRPC in bblfshd Server and Drivers.
-func GRPCOptions(maxMessageSizeMB int) ([]grpc.ServerOption, error) {
-	var err error
-	sizeMB := maxMessageSizeMB
-	if sizeMB >= maxMsgSizeCapMB {
-		err = fmt.Errorf("%s=%d is too big (limit is %dMB), using %d instead",
-			MaxMsgSizeCLIName, sizeMB, maxMsgSizeCapMB-1, DefaulGRPCMaxSendRecvMsgSizeMB)
-		sizeMB = DefaulGRPCMaxSendRecvMsgSizeMB
-	}
-
-	sizeBytes := sizeMB * 1024 * 1024
-	return []grpc.ServerOption{
-		grpc.MaxRecvMsgSize(sizeBytes),
-		grpc.MaxSendMsgSize(sizeBytes),
-	}, err
-}

--- a/driver/server/server.go
+++ b/driver/server/server.go
@@ -75,7 +75,8 @@ func (s *Server) initialize() error {
 
 	grpcOpts, err := cmdutil.GRPCSizeOptions(*maxMessageSize)
 	if err != nil {
-		s.Logger.Warningf(err.Error())
+		s.Logger.Errorf(err.Error())
+		os.Exit(1)
 	}
 	s.Options = grpcOpts
 
@@ -103,7 +104,7 @@ func (s *Server) initializeFlags() {
 	cmd := flag.NewFlagSet("server", flag.ExitOnError)
 	network = cmd.String("network", defaultNetwork, "network type: tcp, tcp4, tcp6, unix or unixpacket.")
 	address = cmd.String("address", defaultAddress, "address to listen.")
-	maxMessageSize = cmdutil.MaxSendRecvMsgSizeMB(cmd)
+	maxMessageSize = cmdutil.FlagMaxGRPCMsgSizeMB(cmd)
 
 	logs.level = cmd.String("log-level", defaultVerbose, "log level: panic, fatal, error, warning, info, debug.")
 	logs.format = cmd.String("log-format", defaultFormat, "format of the logs: text or json.")

--- a/driver/server/server.go
+++ b/driver/server/server.go
@@ -5,6 +5,7 @@ import (
 	"net"
 	"os"
 
+	"gopkg.in/bblfsh/sdk.v2"
 	"gopkg.in/bblfsh/sdk.v2/driver"
 	"gopkg.in/src-d/go-errors.v1"
 )
@@ -15,10 +16,11 @@ var (
 )
 
 var (
-	network *string
-	address *string
-	verbose *string
-	logs    struct {
+	network        *string
+	address        *string
+	verbose        *string
+	maxMessageSize *int
+	logs           struct {
 		level  *string
 		format *string
 		fields *string
@@ -71,6 +73,12 @@ func (s *Server) initialize() error {
 		return err
 	}
 
+	grpcOpts, err := sdk.BuildGRPCOptions(*maxMessageSize)
+	if err != nil {
+		s.Logger.Errorf(err.Error())
+	}
+	s.Options = grpcOpts
+
 	build := "unknown"
 	if m.Build != nil {
 		build = m.Build.Format("2006-01-02T15:04:05Z")
@@ -95,6 +103,8 @@ func (s *Server) initializeFlags() {
 	cmd := flag.NewFlagSet("server", flag.ExitOnError)
 	network = cmd.String("network", defaultNetwork, "network type: tcp, tcp4, tcp6, unix or unixpacket.")
 	address = cmd.String("address", defaultAddress, "address to listen.")
+	maxMessageSize = cmd.Int(sdk.MaxMsgSizeCLIName, sdk.DefaulGRPCMaxMsgSizeMb, sdk.MaxMsgSizeCLIDesc)
+
 	logs.level = cmd.String("log-level", defaultVerbose, "log level: panic, fatal, error, warning, info, debug.")
 	logs.format = cmd.String("log-format", defaultFormat, "format of the logs: text or json.")
 	logs.fields = cmd.String("log-fields", "", "extra fields to add to every log line in json format.")

--- a/driver/server/server.go
+++ b/driver/server/server.go
@@ -5,7 +5,7 @@ import (
 	"net"
 	"os"
 
-	"gopkg.in/bblfsh/sdk.v2"
+	cmdutil "gopkg.in/bblfsh/sdk.v2/cmd"
 	"gopkg.in/bblfsh/sdk.v2/driver"
 	"gopkg.in/src-d/go-errors.v1"
 )
@@ -73,9 +73,9 @@ func (s *Server) initialize() error {
 		return err
 	}
 
-	grpcOpts, err := sdk.GRPCOptions(*maxMessageSize)
+	grpcOpts, err := cmdutil.GRPCSizeOptions(*maxMessageSize)
 	if err != nil {
-		s.Logger.Errorf(err.Error())
+		s.Logger.Warningf(err.Error())
 	}
 	s.Options = grpcOpts
 
@@ -103,7 +103,7 @@ func (s *Server) initializeFlags() {
 	cmd := flag.NewFlagSet("server", flag.ExitOnError)
 	network = cmd.String("network", defaultNetwork, "network type: tcp, tcp4, tcp6, unix or unixpacket.")
 	address = cmd.String("address", defaultAddress, "address to listen.")
-	maxMessageSize = cmd.Int(sdk.MaxMsgSizeCLIName, sdk.DefaulGRPCMaxMsgSizeMb, sdk.MaxMsgSizeCLIDesc)
+	maxMessageSize = cmdutil.MaxSendRecvMsgSizeMB(cmd)
 
 	logs.level = cmd.String("log-level", defaultVerbose, "log level: panic, fatal, error, warning, info, debug.")
 	logs.format = cmd.String("log-format", defaultFormat, "format of the logs: text or json.")

--- a/driver/server/server.go
+++ b/driver/server/server.go
@@ -73,7 +73,7 @@ func (s *Server) initialize() error {
 		return err
 	}
 
-	grpcOpts, err := sdk.BuildGRPCOptions(*maxMessageSize)
+	grpcOpts, err := sdk.GRPCOptions(*maxMessageSize)
 	if err != nil {
 		s.Logger.Errorf(err.Error())
 	}


### PR DESCRIPTION
Part of the https://github.com/bblfsh/client-go/issues/102

Includes:
 - move `sdk.BuildGRPCOptions` from bblfshd to SDK
 - add same CLI `grpc-max-message-size` arg to all Drivers