### PR TITLE
Enable OpenTracing in SDK

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -36,6 +36,12 @@
 
 [[projects]]
   branch = "master"
+  name = "github.com/codahale/hdrhistogram"
+  packages = ["."]
+  revision = "3a0bb77429bd3a61596f5e8a3172445844342120"
+
+[[projects]]
+  branch = "master"
   name = "github.com/containerd/continuity"
   packages = ["pathdriver"]
   revision = "0377f7d767206f3a9e8881d0f02267b0d89c7a62"
@@ -110,6 +116,12 @@
   revision = "53e6ce116135b80d037921a7fdd5138cf32d7a8a"
 
 [[projects]]
+  branch = "master"
+  name = "github.com/grpc-ecosystem/grpc-opentracing"
+  packages = ["go/otgrpc"]
+  revision = "8e809c8a86450a29b90dcc9efbf062d0fe6d9746"
+
+[[projects]]
   name = "github.com/jessevdk/go-flags"
   packages = ["."]
   revision = "c6ca198ec95c841fdb89fc0de7496fed11ab854e"
@@ -164,6 +176,7 @@
   name = "github.com/opentracing/opentracing-go"
   packages = [
     ".",
+    "ext",
     "log"
   ]
   revision = "1949ddbfd147afd4d964a9f00b24eb291e0e7c38"
@@ -225,6 +238,36 @@
   ]
   revision = "f35b8ab0b5a2cef36673838d662e249dd9c94686"
   version = "v1.2.2"
+
+[[projects]]
+  name = "github.com/uber/jaeger-client-go"
+  packages = [
+    ".",
+    "config",
+    "internal/baggage",
+    "internal/baggage/remote",
+    "internal/spanlog",
+    "internal/throttler",
+    "internal/throttler/remote",
+    "log",
+    "rpcmetrics",
+    "thrift",
+    "thrift-gen/agent",
+    "thrift-gen/baggage",
+    "thrift-gen/jaeger",
+    "thrift-gen/sampling",
+    "thrift-gen/zipkincore",
+    "transport",
+    "utils"
+  ]
+  revision = "1a782e2da844727691fef1757c72eb190c2909f0"
+  version = "v2.15.0"
+
+[[projects]]
+  name = "github.com/uber/jaeger-lib"
+  packages = ["metrics"]
+  revision = "ed3a127ec5fef7ae9ea95b01b542c47fbd999ce5"
+  version = "v1.5.0"
 
 [[projects]]
   name = "github.com/x-cray/logrus-prefixed-formatter"
@@ -345,6 +388,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "30597d830d32c3db8943f378f2c11dea1691e15d3251912d4d6e80212e1ced8c"
+  inputs-digest = "de848e8d06535c0133ff260a9efc285d0203fcc9f0cc027ff01e10d864a21e77"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -161,6 +161,15 @@
   version = "v1.0.0-rc5"
 
 [[projects]]
+  name = "github.com/opentracing/opentracing-go"
+  packages = [
+    ".",
+    "log"
+  ]
+  revision = "1949ddbfd147afd4d964a9f00b24eb291e0e7c38"
+  version = "v1.0.2"
+
+[[projects]]
   name = "github.com/ory/dockertest"
   packages = [
     "docker",
@@ -336,6 +345,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "ca31e7da904c3376a4e905523bd4865967d02e2525a2cde8206049038fc607cb"
+  inputs-digest = "30597d830d32c3db8943f378f2c11dea1691e15d3251912d4d6e80212e1ced8c"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/driver/fixtures/fixtures.go
+++ b/driver/fixtures/fixtures.go
@@ -199,6 +199,8 @@ func (s *Suite) testFixturesNative(t *testing.T) {
 }
 
 func (s *Suite) testFixturesUAST(t *testing.T, mode driver.Mode, suf string, blacklist ...string) {
+	ctx := context.Background()
+
 	list, err := ioutil.ReadDir(s.Path)
 	require.NoError(t, err)
 
@@ -226,7 +228,7 @@ func (s *Suite) testFixturesUAST(t *testing.T, mode driver.Mode, suf string, bla
 			name += suffix
 			code := s.readFixturesFile(t, name)
 
-			ctx, cancel := context.WithTimeout(context.Background(), parseTimeout)
+			ctx, cancel := context.WithTimeout(ctx, parseTimeout)
 			ast, err := dr.Parse(ctx, string(code))
 			cancel()
 			if err != nil {
@@ -240,7 +242,7 @@ func (s *Suite) testFixturesUAST(t *testing.T, mode driver.Mode, suf string, bla
 
 			tr := s.Transforms
 			if s.WritePreprocessed {
-				ua, err := tr.Do(driver.ModePreprocessed, code, ast)
+				ua, err := tr.Do(ctx, driver.ModePreprocessed, code, ast)
 				require.NoError(t, err)
 
 				un, err := marshalUAST(ua)
@@ -248,7 +250,7 @@ func (s *Suite) testFixturesUAST(t *testing.T, mode driver.Mode, suf string, bla
 
 				s.writeFixturesFile(t, name+preExt, string(un))
 			}
-			ua, err := tr.Do(mode, code, ast)
+			ua, err := tr.Do(ctx, mode, code, ast)
 			require.NoError(t, err)
 
 			if len(blacklist) != 0 {
@@ -335,6 +337,7 @@ func (s *Suite) benchmarkTransform(b *testing.B, legacy bool) {
 	if s.BenchName == "" {
 		b.SkipNow()
 	}
+	ctx := context.Background()
 	code := s.readFixturesFile(b, s.BenchName+s.Ext)
 
 	tr := s.Transforms
@@ -345,7 +348,7 @@ func (s *Suite) benchmarkTransform(b *testing.B, legacy bool) {
 	require.NoError(b, err)
 	defer dr.Close()
 
-	ctx, cancel := context.WithTimeout(context.Background(), parseTimeout)
+	ctx, cancel := context.WithTimeout(ctx, parseTimeout)
 	rast, err := dr.Parse(ctx, string(code))
 	cancel()
 	if err != nil {
@@ -358,7 +361,7 @@ func (s *Suite) benchmarkTransform(b *testing.B, legacy bool) {
 	for i := 0; i < b.N; i++ {
 		ast := rast.Clone()
 
-		ua, err := tr.Do(driver.ModeSemantic, code, ast)
+		ua, err := tr.Do(ctx, driver.ModeSemantic, code, ast)
 		if err != nil {
 			b.Fatal(err)
 		}

--- a/driver/fixtures/fixtures.go
+++ b/driver/fixtures/fixtures.go
@@ -337,7 +337,6 @@ func (s *Suite) benchmarkTransform(b *testing.B, legacy bool) {
 	if s.BenchName == "" {
 		b.SkipNow()
 	}
-	ctx := context.Background()
 	code := s.readFixturesFile(b, s.BenchName+s.Ext)
 
 	tr := s.Transforms
@@ -348,7 +347,7 @@ func (s *Suite) benchmarkTransform(b *testing.B, legacy bool) {
 	require.NoError(b, err)
 	defer dr.Close()
 
-	ctx, cancel := context.WithTimeout(ctx, parseTimeout)
+	ctx, cancel := context.WithTimeout(context.Background(), parseTimeout)
 	rast, err := dr.Parse(ctx, string(code))
 	cancel()
 	if err != nil {

--- a/driver/native/native.go
+++ b/driver/native/native.go
@@ -149,13 +149,10 @@ func (d *Driver) writeRequest(ctx context.Context, req *parseRequest) error {
 
 	if !deadline.IsZero() {
 		d.stdin.SetWriteDeadline(deadline)
+		defer d.stdin.SetWriteDeadline(time.Time{})
 	}
 
-	err := d.enc.Encode(req)
-	if !deadline.IsZero() {
-		d.stdin.SetWriteDeadline(time.Time{})
-	}
-	return err
+	return d.enc.Encode(req)
 }
 
 func (d *Driver) readResponse(ctx context.Context) (*parseResponse, error) {
@@ -166,13 +163,11 @@ func (d *Driver) readResponse(ctx context.Context) (*parseResponse, error) {
 
 	if !deadline.IsZero() {
 		d.stdout.SetReadDeadline(deadline)
+		defer d.stdout.SetReadDeadline(time.Time{})
 	}
 
 	var r parseResponse
 	err := d.dec.Decode(&r)
-	if !deadline.IsZero() {
-		d.stdout.SetReadDeadline(time.Time{})
-	}
 	if err != nil {
 		return nil, err
 	}

--- a/driver/native/native.go
+++ b/driver/native/native.go
@@ -12,6 +12,8 @@ import (
 	"sync"
 	"time"
 
+	"github.com/opentracing/opentracing-go"
+
 	"gopkg.in/bblfsh/sdk.v2/driver"
 	derrors "gopkg.in/bblfsh/sdk.v2/driver/errors"
 	"gopkg.in/bblfsh/sdk.v2/driver/native/jsonlines"
@@ -139,8 +141,49 @@ func (r *parseResponse) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
+func (d *Driver) writeRequest(ctx context.Context, req *parseRequest) error {
+	deadline, _ := ctx.Deadline()
+
+	sp, _ := opentracing.StartSpanFromContext(ctx, "bblfsh.native.Parse.encodeReq")
+	defer sp.Finish()
+
+	if !deadline.IsZero() {
+		d.stdin.SetWriteDeadline(deadline)
+	}
+
+	err := d.enc.Encode(req)
+	if !deadline.IsZero() {
+		d.stdin.SetWriteDeadline(time.Time{})
+	}
+	return err
+}
+
+func (d *Driver) readResponse(ctx context.Context) (*parseResponse, error) {
+	deadline, _ := ctx.Deadline()
+
+	sp, _ := opentracing.StartSpanFromContext(ctx, "bblfsh.native.Parse.decodeResp")
+	defer sp.Finish()
+
+	if !deadline.IsZero() {
+		d.stdout.SetReadDeadline(deadline)
+	}
+
+	var r parseResponse
+	err := d.dec.Decode(&r)
+	if !deadline.IsZero() {
+		d.stdout.SetReadDeadline(time.Time{})
+	}
+	if err != nil {
+		return nil, err
+	}
+	return &r, nil
+}
+
 // Parse sends a request to the native driver and returns its response.
-func (d *Driver) Parse(ctx context.Context, src string) (nodes.Node, error) {
+func (d *Driver) Parse(rctx context.Context, src string) (nodes.Node, error) {
+	sp, ctx := opentracing.StartSpanFromContext(rctx, "bblfsh.native.Parse")
+	defer sp.Finish()
+
 	if !d.running {
 		return nil, driver.ErrDriverFailure.Wrap(ErrNotRunning.New())
 	}
@@ -150,21 +193,12 @@ func (d *Driver) Parse(ctx context.Context, src string) (nodes.Node, error) {
 		return nil, driver.ErrDriverFailure.Wrap(err)
 	}
 
-	deadline, _ := ctx.Deadline()
-
 	d.mu.Lock()
 	defer d.mu.Unlock()
 
-	if !deadline.IsZero() {
-		d.stdin.SetWriteDeadline(deadline)
-	}
-
-	err = d.enc.Encode(&parseRequest{
+	err = d.writeRequest(ctx, &parseRequest{
 		Content: str, Encoding: d.ec,
 	})
-	if !deadline.IsZero() {
-		d.stdin.SetWriteDeadline(time.Time{})
-	}
 	if err != nil {
 		// Cannot write data - this means the stream is broken or driver crashed.
 		// We will try to recover by reading the response, but since it might be
@@ -179,15 +213,7 @@ func (d *Driver) Parse(ctx context.Context, src string) (nodes.Node, error) {
 		return nil, driver.ErrDriverFailure.Wrap(fmt.Errorf("error: %v; %s", err, string(raw)))
 	}
 
-	if !deadline.IsZero() {
-		d.stdout.SetReadDeadline(deadline)
-	}
-
-	var r parseResponse
-	err = d.dec.Decode(&r)
-	if !deadline.IsZero() {
-		d.stdout.SetReadDeadline(time.Time{})
-	}
+	r, err := d.readResponse(ctx)
 	if err != nil {
 		return nil, driver.ErrDriverFailure.Wrap(err)
 	}

--- a/driver/server/grpc.go
+++ b/driver/server/grpc.go
@@ -20,12 +20,10 @@ import (
 // NewGRPCServer creates a gRPC server.
 func NewGRPCServer(drv driver.DriverModule, opts ...grpc.ServerOption) *grpc.Server {
 	tracer := opentracing.GlobalTracer()
-	if tracer != nil {
-		opts = append(opts,
-			grpc.UnaryInterceptor(otgrpc.OpenTracingServerInterceptor(tracer)),
-			grpc.StreamInterceptor(otgrpc.OpenTracingStreamServerInterceptor(tracer)),
-		)
-	}
+	opts = append(opts,
+		grpc.UnaryInterceptor(otgrpc.OpenTracingServerInterceptor(tracer)),
+		grpc.StreamInterceptor(otgrpc.OpenTracingStreamServerInterceptor(tracer)),
+	)
 	srv := grpc.NewServer(opts...)
 
 	protocol1.DefaultService = service{drv}

--- a/driver/server/grpc.go
+++ b/driver/server/grpc.go
@@ -19,6 +19,7 @@ import (
 
 // NewGRPCServer creates a gRPC server.
 func NewGRPCServer(drv driver.DriverModule, opts ...grpc.ServerOption) *grpc.Server {
+	// always pass tracing options - they are easy to forget
 	tracer := opentracing.GlobalTracer()
 	opts = append(opts,
 		grpc.UnaryInterceptor(otgrpc.OpenTracingServerInterceptor(tracer)),

--- a/driver/server/server.go
+++ b/driver/server/server.go
@@ -15,8 +15,12 @@ import (
 )
 
 var (
-	ErrInvalidLogger       = errors.NewKind("invalid logger configuration")
-	ErrInvalidTracer       = errors.NewKind("invalid tracer configuration")
+	// ErrInvalidTracer is returned by the driver server when the logger configuration is wrong.
+	ErrInvalidLogger = errors.NewKind("invalid logger configuration")
+	// ErrInvalidTracer is returned by the driver server when the tracing configuration is wrong.
+	ErrInvalidTracer = errors.NewKind("invalid tracer configuration")
+	// ErrUnsupportedLanguage is returned by the language server if the language in the request
+	// is not supported by the driver.
 	ErrUnsupportedLanguage = errors.NewKind("unsupported language: %q")
 )
 

--- a/driver/server/server.go
+++ b/driver/server/server.go
@@ -40,6 +40,8 @@ type Server struct {
 
 	d driver.DriverModule
 
+	// closers is a list of things to be closed
+	// TODO: proper driver shutdown logic; it's unused right now
 	closers []io.Closer
 }
 

--- a/driver/server/server.go
+++ b/driver/server/server.go
@@ -45,7 +45,7 @@ type Server struct {
 
 // NewServer returns a new server for a given Driver.
 func NewServer(d driver.DriverModule) *Server {
-	return &Server{d: d, grpc: NewGRPCServer(d)}
+	return &Server{d: d}
 }
 
 // Start executes the binary driver and start to listen in the network and

--- a/protocol/driver.go
+++ b/protocol/driver.go
@@ -5,6 +5,8 @@ import (
 	"context"
 	"errors"
 
+	"github.com/opentracing/opentracing-go"
+
 	xcontext "golang.org/x/net/context"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
@@ -43,7 +45,10 @@ type driverServer struct {
 	d driver.Driver
 }
 
-func (s *driverServer) Parse(ctx xcontext.Context, req *ParseRequest) (*ParseResponse, error) {
+func (s *driverServer) Parse(rctx xcontext.Context, req *ParseRequest) (*ParseResponse, error) {
+	sp, ctx := opentracing.StartSpanFromContext(rctx, "bblfsh.server.Parse")
+	defer sp.Finish()
+
 	opts := &driver.ParseOptions{
 		Mode:     driver.Mode(req.Mode),
 		Language: req.Language,
@@ -67,6 +72,10 @@ func (s *driverServer) Parse(ctx xcontext.Context, req *ParseRequest) (*ParseRes
 		// partial parse or syntax error; we will send an OK status code, but will fill Errors field
 		resp.Errors = toParseErrors(cause)
 	}
+
+	dsp, _ := opentracing.StartSpanFromContext(ctx, "uast.Encode")
+	defer dsp.Finish()
+
 	buf := bytes.NewBuffer(nil)
 	err = nodesproto.WriteTo(buf, n)
 	if err != nil {
@@ -80,7 +89,10 @@ type client struct {
 	c DriverClient
 }
 
-func (c *client) Parse(ctx context.Context, src string, opts *driver.ParseOptions) (nodes.Node, error) {
+func (c *client) Parse(rctx context.Context, src string, opts *driver.ParseOptions) (nodes.Node, error) {
+	sp, ctx := opentracing.StartSpanFromContext(rctx, "bblfsh.client.Parse")
+	defer sp.Finish()
+
 	req := &ParseRequest{Content: src}
 	if opts != nil {
 		req.Mode = Mode(opts.Mode)
@@ -108,6 +120,10 @@ func (c *client) Parse(ctx context.Context, src string, opts *driver.ParseOption
 	if opts != nil && opts.Language == "" {
 		opts.Language = resp.Language
 	}
+
+	dsp, _ := opentracing.StartSpanFromContext(ctx, "uast.Decode")
+	defer dsp.Finish()
+
 	// it may be still a parsing error
 	return resp.Nodes()
 }


### PR DESCRIPTION
Enable OpenTracing and instrument driver operations with spans.

![image](https://user-images.githubusercontent.com/676724/48959036-7481c180-ef6b-11e8-8887-84b3aeca5a35.png)
