### PR TITLE
Reintroduce InlineImport

### DIFF
--- a/uast/uast.go
+++ b/uast/uast.go
@@ -40,6 +40,7 @@ func init() {
 		Import{},
 		RuntimeImport{},
 		RuntimeReImport{},
+		InlineImport{},
 		Argument{},
 		FunctionType{},
 		Function{},
@@ -322,7 +323,7 @@ type RuntimeImport Import
 
 type RuntimeReImport RuntimeImport
 
-//type InlineImport Import
+type InlineImport Import
 
 type Argument struct {
 	GenNode


### PR DESCRIPTION
`InlineImport` was discussed and approved in the beginning of Semantic UAST conversion, but was disabled in SDK until this time.

Thanks to the great work made by @juanjux on https://github.com/bblfsh/cpp-driver/pull/16, we now need to get this type back to SDK to use in C/C++ driver.

P.S. Sorry, there is no godoc for this type. Should be done separately by dumping parts of the design doc into Go files.

Signed-off-by: Denys Smirnov <denys@sourced.tech>