### PR TITLE
Append should pass an empty array instead of nil

### DIFF
--- a/uast/transformer/arrays.go
+++ b/uast/transformer/arrays.go
@@ -203,9 +203,6 @@ func (op opAppend) Check(st *State, n nodes.Node) (bool, error) {
 	// and the part we will use for sub-array checks
 	tail := len(arr) - len(sarr)
 	sub, arrs := arr[:tail], arr[tail:]
-	if len(sub) == 0 {
-		sub = nil
-	}
 	if ok, err := op.op.Check(st, sub); err != nil {
 		return false, errAppend.Wrap(err)
 	} else if !ok {

--- a/uast/transformer/ops_test.go
+++ b/uast/transformer/ops_test.go
@@ -497,6 +497,71 @@ var opsCases = []struct {
 			}
 		},
 	},
+	{
+		name: "append complex",
+		inp: func() un.Node {
+			return un.Object{
+				"type": un.String("A"),
+				"arr": un.Array{
+					un.Object{
+						"type": un.String("B"),
+						"name": un.String("B1"),
+					},
+				},
+			}
+		},
+		src: Fields{
+			{Name: "type", Op: String("A")},
+			{
+				Name: "arr", Optional: "hasArr",
+				Op: Append(
+					Each("elems",
+						Obj{
+							"type": String("B"),
+							"name": Var("name"),
+						},
+					),
+					Arr(
+						Obj{
+							"type": String("B"),
+							"name": Var("a1_name"),
+						},
+					),
+				),
+			},
+		},
+		dst: Fields{
+			{Name: "type", Op: String("A")},
+			{
+				Name: "arr", Optional: "hasArr",
+				Op: Append(
+					Each("elems",
+						Obj{
+							"type":  String("B"),
+							"name2": Var("name"),
+						},
+					),
+					Arr(
+						Obj{
+							"type":  String("B"),
+							"name2": Var("a1_name"),
+						},
+					),
+				),
+			},
+		},
+		exp: func() un.Node {
+			return un.Object{
+				"type": un.String("A"),
+				"arr": un.Array{
+					un.Object{
+						"type":  un.String("B"),
+						"name2": un.String("B1"),
+					},
+				},
+			}
+		},
+	},
 }
 
 func TestOps(t *testing.T) {


### PR DESCRIPTION
`Append` operation in DSL accepts two parameters: an operation applied to the main part of an array (variable length) and the list of array operations applied to the tail of an array (fixed length).

For some reason, if the length of tail exactly matches the length of an input array, the transform passes `nil` to the main operation (variable length is zero). This might lead to a transformation failure, since the main operation might validate that passed object is an array and will fail with `nil`.

This was probably done at the early stages of DSL development to account for some specific cases. Right now the DSL contains all the functions needed, so this edge case should not appear in practice. 

This change makes `Append` to return an empty slice to the main operation for the case described above.

I've tested this change on few drivers that use it, and none of then rely on the old behavior, so it should be safe to merge.

Signed-off-by: Denys Smirnov <denys@sourced.tech>