### PR TITLE
Enable fixtures benchmarks

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language: go
 
 go:
   - '1.10'
+  - '1.11'
   - tip
 
 go_import_path: gopkg.in/bblfsh/sdk.v2
@@ -13,15 +14,10 @@ matrix:
 
 
 before_install:
-  - sudo apt-get -qq update
-  - sudo apt-get install -y libxml2-dev
-  - go get -v gopkg.in/bblfsh/client-go.v1/... || true
-  - cd $GOPATH/src/gopkg.in/bblfsh/client-go.v1
-  - make dependencies
-
   - cd $GOPATH/src/gopkg.in/bblfsh/sdk.v2
   - make validate-commit
-  - go get -t -v ./...
+  - wget -O dep https://github.com/golang/dep/releases/download/v0.4.1/dep-linux-amd64 && chmod +x dep
+  - ./dep ensure --vendor-only
 
 script:
   - make test-coverage

--- a/build/test.go
+++ b/build/test.go
@@ -114,6 +114,9 @@ func (d *Driver) testFixtures(image string, bench bool) error {
 	if err := d.runContainer(cli, benchLog, opts); err != nil {
 		return err
 	}
+	if err = benchLog.Close(); err != nil {
+		return err
+	}
 	return nil
 }
 

--- a/build/test.go
+++ b/build/test.go
@@ -84,14 +84,18 @@ func (d *Driver) testFixtures(image string, bench bool) error {
 			Binds:      []string{mnt},
 		},
 	}
-	// run tests
+	// Run tests.
+	//
+	// Write output to buffer and show it only if the test fails.
 	if err := d.runContainer(cli, nil, opts); err != nil {
 		return err
 	}
 	if !bench {
 		return nil
 	}
-	// run benchmarks
+	// Run benchmarks.
+	//
+	// We do it in two separate passes to isolate benchmark output from test output.
 	outPath := filepath.Join(d.root, "bench.txt")
 	fmt.Fprintf(os.Stderr, "running benchmarks (%s)\n", outPath)
 	benchLog, err := os.Create(outPath)

--- a/cmd/bblfsh-sdk/cmd/build.go
+++ b/cmd/bblfsh-sdk/cmd/build.go
@@ -35,6 +35,7 @@ const TestCommandDescription = "tests the driver using fixtures"
 type TestCommand struct {
 	cmd.Command
 	Bblfshd string `long:"bblfshd" description:"bblfshd version to test with"`
+	Bench   bool   `short:"b" long:"bench" description:"benchmark the driver"`
 }
 
 func (c *TestCommand) Execute(args []string) error {
@@ -46,7 +47,7 @@ func (c *TestCommand) Execute(args []string) error {
 	if len(args) != 0 {
 		image = args[0]
 	}
-	return d.Test(c.Bblfshd, image)
+	return d.Test(c.Bblfshd, image, c.Bench)
 }
 
 const TagCommandDescription = "returns a version tag for the driver"


### PR DESCRIPTION
Add a `--bench` (`-b`) flag to `bblfsh-sdk test` to run benchmarks for the driver. All files with `./fixtures/bench_` will be used during the benchmark, and the results will be written to `bench.txt`.

Another possibility might be to add a flag to enable profiling in the driver, but this is not driver-related actually. The profile can only be enabled in the Go part of the driver, thus it will be measuring the performance of the transformation DSL. It can be analyzed without running the driver in Docker, by loading the same UAST file with SDK and importing the appropriate transformation package from the driver.

Signed-off-by: Denys Smirnov <denys@sourced.tech>