### PR TITLE
Define Ambiguity node

### DIFF
--- a/uast/types.go
+++ b/uast/types.go
@@ -212,6 +212,7 @@ func fieldName(f reflect.StructField) (string, bool, error) {
 var (
 	reflString  = reflect.TypeOf("")
 	reflAny     = reflect.TypeOf((*Any)(nil)).Elem()
+	reflAnyArr  = reflect.TypeOf([]Any{})
 	reflNode    = reflect.TypeOf((*nodes.Node)(nil)).Elem()
 	reflNodeExt = reflect.TypeOf((*nodes.External)(nil)).Elem()
 )
@@ -353,6 +354,26 @@ func setAnyOrNode(dst reflect.Value, n nodes.External) (bool, error) {
 			return false, err
 		}
 		dst.Set(reflect.ValueOf(nd))
+		return true, nil
+	} else if rt == reflAnyArr {
+		narr, ok := n.(nodes.ExternalArray)
+		if !ok {
+			return false, nil
+		}
+		sz := narr.Size()
+		arr := make([]Any, 0, sz)
+		for i := 0; i < sz; i++ {
+			e := narr.ValueAt(i)
+			var v Any = e
+			if nv, err := NewValue(TypeOf(e)); err == nil {
+				if err = nodeAs(e, nv); err != nil {
+					return false, err
+				}
+				v = nv.Interface()
+			}
+			arr = append(arr, v)
+		}
+		dst.Set(reflect.ValueOf(arr))
 		return true, nil
 	}
 	return false, nil

--- a/uast/types_test.go
+++ b/uast/types_test.go
@@ -72,6 +72,46 @@ var casesToNode = []struct {
 		},
 	},
 	{
+		name: "Ambiguity",
+		obj: Ambiguity{
+			GenNode: GenNode{
+				Positions: Positions{
+					KeyStart: {Offset: 3, Line: 2, Col: 1},
+					KeyEnd:   {Offset: 8, Line: 2, Col: 6},
+				},
+			},
+			Alternatives: []Any{
+				Identifier{Name: "a", GenNode: GenNode{
+					Positions: Positions{},
+				}},
+				String{Value: "a", GenNode: GenNode{
+					Positions: Positions{},
+				}},
+			},
+		},
+		exp: nodes.Object{
+			KeyType: nodes.String("uast:Ambiguity"),
+			KeyPos: nodes.Object{
+				KeyType:  nodes.String(TypePositions),
+				KeyStart: expPos(3, 2, 1),
+				KeyEnd:   expPos(8, 2, 6),
+			},
+			"Alternatives": nodes.Array{
+				nodes.Object{
+					KeyType: nodes.String("uast:Identifier"),
+					KeyPos:  nodes.Object{KeyType: nodes.String(TypePositions)},
+					"Name":  nodes.String("a"),
+				},
+				nodes.Object{
+					KeyType:  nodes.String("uast:String"),
+					KeyPos:   nodes.Object{KeyType: nodes.String(TypePositions)},
+					"Value":  nodes.String("a"),
+					"Format": nodes.String(""),
+				},
+			},
+		},
+	},
+	{
 		name: "Alias",
 		obj: Alias{
 			GenNode: GenNode{

--- a/uast/uast.go
+++ b/uast/uast.go
@@ -29,6 +29,7 @@ func init() {
 		Position{},
 		Positions{},
 		GenNode{},
+		Ambiguity{},
 		Identifier{},
 		String{},
 		QualifiedIdentifier{},
@@ -264,6 +265,16 @@ type Scope = Any
 
 type GenNode struct {
 	Positions Positions `json:"@pos,omitempty"`
+}
+
+// Ambiguity node can be used when the driver cannot interpret the node without additional information, but can propose
+// a small number of possible meanings of this node.
+//
+// An example might be an ambiguity between a builtin identifier like "true" versus the local definition of the same
+// identifier.
+type Ambiguity struct {
+	GenNode
+	Alternatives []Any `json:"Alternatives"`
 }
 
 type Identifier struct {


### PR DESCRIPTION
This PR defines a new node type for SemUAST called `Ambiguity`.

This node will represent multiple alternative meanings of the same node in case driver cannot determine its type with a 100% certainty (without running the compiler or symbol resolution), but can propose a small number of alternative meanings.

The first use case is that languages like Python, Go and some others have built-in names like `True`/`False` that can be redefined. The driver might mark them as `Identifier` and be done with it, but this won't be that helpful for the end user. In fact, the driver knows that in this specific language the `True` identifier with 99% certainty is a boolean literal. So instead of dumping a generic `Identifier`, the driver may emit an `Ambiguity` node with both `Bool` and `Identifier` nodes.

The second use case is that sometimes operators might be overloaded in the language itself. I don't want to state that this will solve an issue of user-defined operator overloading, though. The current use case is a bit simpler for now. For example, in Python there is a `%` operator that can be a modulo operator or a string interpolation operator. The driver may emit both possible versions as an `Ambiguity` node if it cannot assert the type of the first operand.

Later, this may help to identify places in UAST that needs additional analysis. And it will immediately allow searching for nodes of more specific types in Babelfish instead of generic ones.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bblfsh/sdk/337)
<!-- Reviewable:end -->
