### PR TITLE
Define Bool node (boolean literal)

### DIFF
--- a/uast/types_test.go
+++ b/uast/types_test.go
@@ -72,6 +72,27 @@ var casesToNode = []struct {
 		},
 	},
 	{
+		name: "Bool",
+		obj: Bool{
+			GenNode: GenNode{
+				Positions: Positions{
+					KeyStart: {Offset: 3, Line: 2, Col: 1},
+					KeyEnd:   {Offset: 8, Line: 2, Col: 6},
+				},
+			},
+			Value: true,
+		},
+		exp: nodes.Object{
+			KeyType: nodes.String("uast:Bool"),
+			KeyPos: nodes.Object{
+				KeyType:  nodes.String(TypePositions),
+				KeyStart: expPos(3, 2, 1),
+				KeyEnd:   expPos(8, 2, 6),
+			},
+			"Value": nodes.Bool(true),
+		},
+	},
+	{
 		name: "Alias",
 		obj: Alias{
 			GenNode: GenNode{

--- a/uast/uast.go
+++ b/uast/uast.go
@@ -31,6 +31,7 @@ func init() {
 		GenNode{},
 		Identifier{},
 		String{},
+		Bool{},
 		QualifiedIdentifier{},
 		Comment{},
 		Group{},
@@ -345,4 +346,10 @@ type Function struct {
 	GenNode
 	Type FunctionType `json:"Type"`
 	Body *Block       `json:"Body"`
+}
+
+// Bool is a boolean literal.
+type Bool struct {
+	GenNode
+	Value bool `json:"Value"`
 }


### PR DESCRIPTION
We already have a `String` literal node, and this PR goes one step further and defines a boolean literal node (`Bool`) in SemUAST.

The definition of the node is pretty streightforward: it's a boolean value that can be either "true" or "false".

This node type is useless for some drivers without https://github.com/bblfsh/sdk/pull/337.

Signed-off-by: Denys Smirnov <denys@sourced.tech>