### PR TITLE
Support Unicode character offsets

### DIFF
--- a/assets/skeleton/bindata.go
+++ b/assets/skeleton/bindata.go
@@ -1088,7 +1088,7 @@ var Native = Transformers([][]Transformer{
 //
 // https://godoc.org/gopkg.in/bblfsh/sdk.v2/uast/transformer/positioner
 var Code = []CodeTransformer{
-	positioner.NewFillLineColFromOffset(),
+	positioner.FromOffset(),
 }
 
 // Annotations is a list of individual transformations to annotate a native AST with roles.
@@ -1107,7 +1107,7 @@ func driverNormalizerAnnotationGo() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "driver/normalizer/annotation.go", size: 1132, mode: os.FileMode(420), modTime: time.Unix(1, 0)}
+	info := bindataFileInfo{name: "driver/normalizer/annotation.go", size: 1118, mode: os.FileMode(420), modTime: time.Unix(1, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }

--- a/etc/skeleton/driver/normalizer/annotation.go
+++ b/etc/skeleton/driver/normalizer/annotation.go
@@ -25,7 +25,7 @@ var Native = Transformers([][]Transformer{
 //
 // https://godoc.org/gopkg.in/bblfsh/sdk.v2/uast/transformer/positioner
 var Code = []CodeTransformer{
-	positioner.NewFillLineColFromOffset(),
+	positioner.FromOffset(),
 }
 
 // Annotations is a list of individual transformations to annotate a native AST with roles.

--- a/uast/transformer/positioner/positions.go
+++ b/uast/transformer/positioner/positions.go
@@ -13,24 +13,39 @@ var _ transformer.CodeTransformer = Positioner{}
 
 const cloneObj = false
 
-// NewFillOffsetFromLineCol gets the original source code and its parsed form
-// as *Node and fills every Offset field using its Line and Column.
-func NewFillOffsetFromLineCol() Positioner {
-	return Positioner{method: fillOffsetFromLineCol}
+// FromLineCol fills the Offset field of all Position nodes by using their Line and Col.
+func FromLineCol() Positioner {
+	return Positioner{method: fromLineCol}
 }
 
-// NewFillLineColFromOffset gets the original source code and its parsed form
-// as *Node and fills every Line and Column field using its Offset.
+// NewFillOffsetFromLineCol fills the Offset field of all Position nodes by using
+// their Line and Col.
+//
+// Deprecated: see FromLineCol
+func NewFillOffsetFromLineCol() Positioner {
+	return FromLineCol()
+}
+
+// FromOffset the Line and Col fields of all Position nodes by using their Offset.
+func FromOffset() Positioner {
+	return Positioner{method: fromOffset}
+}
+
+// NewFillLineColFromOffset the Line and Col fields of all Position nodes by using
+// their Offset.
+//
+// Deprecated: see FromOffset
 func NewFillLineColFromOffset() Positioner {
-	return Positioner{method: fillLineColFromOffset}
+	return FromOffset()
 }
 
 // Positioner is a transformation that only changes positional information.
+// The transformation should be initialized with the source code by calling OnCode.
 type Positioner struct {
 	method func(*positionIndex, *uast.Position) error
 }
 
-// OnCode uses the source code to update positional information.
+// OnCode uses the source code to update positional information of UAST nodes.
 func (t Positioner) OnCode(code string) transformer.Transformer {
 	idx := newPositionIndex([]byte(code))
 	return transformer.TransformObjFunc(func(o nodes.Object) (nodes.Object, bool, error) {
@@ -51,7 +66,7 @@ func (t Positioner) OnCode(code string) transformer.Transformer {
 	})
 }
 
-func fillOffsetFromLineCol(idx *positionIndex, pos *uast.Position) error {
+func fromLineCol(idx *positionIndex, pos *uast.Position) error {
 	offset, err := idx.Offset(int(pos.Line), int(pos.Col))
 	if err != nil {
 		return err
@@ -60,7 +75,7 @@ func fillOffsetFromLineCol(idx *positionIndex, pos *uast.Position) error {
 	return nil
 }
 
-func fillLineColFromOffset(idx *positionIndex, pos *uast.Position) error {
+func fromOffset(idx *positionIndex, pos *uast.Position) error {
 	line, col, err := idx.LineCol(int(pos.Offset))
 	if err != nil {
 		return err

--- a/uast/transformer/positioner/positions_test.go
+++ b/uast/transformer/positioner/positions_test.go
@@ -128,7 +128,7 @@ a3`
 		{Offset: 12, Line: 3, Col: 3},
 	}
 
-	ind := newPositionIndex([]byte(source), false)
+	ind := newPositionIndex([]byte(source))
 	for _, c := range cases {
 		t.Run("", func(t *testing.T) {
 			line, col, err := ind.LineCol(int(c.Offset))
@@ -165,7 +165,7 @@ a3`
 		{runeOff: 11, byteOff: 12, line: 3, col: 3},
 	}
 
-	ind := newPositionIndex([]byte(source), true)
+	ind := newPositionIndexUnicode([]byte(source))
 	for _, c := range cases {
 		t.Run("", func(t *testing.T) {
 			off, err := ind.RuneOffset(c.runeOff)

--- a/uast/transformer/positioner/positions_test.go
+++ b/uast/transformer/positioner/positions_test.go
@@ -47,7 +47,7 @@ func TestFillLineColNested(t *testing.T) {
 		}},
 	}
 
-	p := NewFillLineColFromOffset()
+	p := FromOffset()
 	out, err := p.OnCode(data).Do(input)
 	require.NoError(err)
 	require.Equal(expected, out)
@@ -80,7 +80,7 @@ func TestFillOffsetNested(t *testing.T) {
 		}},
 	}
 
-	p := NewFillOffsetFromLineCol()
+	p := FromLineCol()
 	out, err := p.OnCode(data).Do(input)
 	require.NoError(err)
 	require.Equal(expected, out)
@@ -101,7 +101,7 @@ func TestFillOffsetEmptyFile(t *testing.T) {
 		uast.KeyEnd:   fullPos(0, 1, 1),
 	}
 
-	p := NewFillOffsetFromLineCol()
+	p := FromLineCol()
 	out, err := p.OnCode(data).Do(input)
 	require.NoError(err)
 	require.Equal(expected, out)


### PR DESCRIPTION
Currently, SDK only supports positional offset in bytes or line-column pair, where a column is given in bytes.

PR implements a new `Positioner` that converts Unicode character offsets to a byte offset and a line-column pair (in bytes as well).

Also, refactor long name for position functions to something shorter and place a deprecation note on the old ones.

This is change will allow to solve issues like https://github.com/bblfsh/javascript-driver/issues/25.