### PR TITLE
More DSL operations to check objects

### DIFF
--- a/uast/transformer/ast.go
+++ b/uast/transformer/ast.go
@@ -412,11 +412,11 @@ func StringToRolesMap(m map[string][]role.Role) map[nodes.Value]ArrayOp {
 // Since rules are applied depth-first, this operation will work properly only in a separate mapping step.
 // In other cases it will apply itself before parent node appends field roles.
 func AnnotateIfNoRoles(typ string, roles ...role.Role) Mapping {
-	return Map(
-		Check( // TODO: CheckObj
-			Not(Has{
-				uast.KeyRoles: AnyNode(nil),
-			}),
+	return MapObj(
+		CheckObj(
+			HasFields{
+				uast.KeyRoles: false,
+			},
 			Part("_", Obj{
 				uast.KeyType: String(typ),
 			}),

--- a/uast/transformer/ops.go
+++ b/uast/transformer/ops.go
@@ -1530,10 +1530,32 @@ func (op *opIn) Check(st *State, n nodes.Node) (bool, error) {
 	return ok, nil
 }
 
+// Cases acts like a switch statement: it checks multiple operations, picks one that
+// matches node structure and writes the number of the taken branch to the variable.
+//
+// Operations in branches should not be ambiguous. They should not overlap.
 func Cases(vr string, cases ...Op) Op {
 	return &opCases{vr: vr, cases: cases}
 }
 
+// CasesObj is similar to Cases, but only works on object nodes. It also allows to specify
+// a common set of operations that will be executed for each branch.
+//
+// It is also required for all branches in CasesObj to have exactly the same set of keys.
+//
+// Example:
+//   CasesObj("case",
+//     // common
+//     Obj{
+//       "type": String("ident"),
+//     },
+//     Objects{
+//       // case 1: A
+//       {"name": String("A")},
+//       // case 1: B
+//       {"name": String("B")},
+//     },
+//   )
 func CasesObj(vr string, common ObjectOp, cases ObjectOps) ObjectOp {
 	list := cases.ObjectOps()
 	if len(list) == 0 {

--- a/uast/transformer/ops_test.go
+++ b/uast/transformer/ops_test.go
@@ -429,7 +429,7 @@ var opsCases = []struct {
 			}
 		},
 		src: Check(
-			Not(Has{"b": Any(nil)}),
+			Not(Has{"b": Any()}),
 			Obj{
 				u.KeyType: String("node"),
 				"val":     Var("x"),

--- a/uast/transformer/ops_test.go
+++ b/uast/transformer/ops_test.go
@@ -644,6 +644,61 @@ var opsCases = []struct {
 			}
 		},
 	},
+	{
+		name: "cases",
+		inp: func() un.Node {
+			return un.Array{
+				un.Object{
+					"type": un.String("ident"),
+					"name": un.Array{un.String("A")},
+				},
+				un.Object{
+					"type": un.String("ident"),
+					"name": un.String("B"),
+				},
+			}
+		},
+		src: CasesObj("case",
+			// common
+			Obj{"type": String("ident")},
+			Objects{
+				// case 1: array
+				Obj{"name": Arr(Var("name"))},
+				// case 2: string
+				Obj{"name": Check(OfKind(un.KindString), Var("name"))},
+			},
+		),
+		dst: CasesObj("case",
+			// common
+			Obj{"type": String("ident")},
+			Objects{
+				// case 1: array
+				Obj{
+					"name2": Var("name"),
+					"arr":   Bool(true),
+				},
+				// case 2: string
+				Obj{
+					"name2": Var("name"),
+					"arr":   Bool(false),
+				},
+			},
+		),
+		exp: func() un.Node {
+			return un.Array{
+				un.Object{
+					"type":  un.String("ident"),
+					"name2": un.String("A"),
+					"arr":   un.Bool(true),
+				},
+				un.Object{
+					"type":  un.String("ident"),
+					"name2": un.String("B"),
+					"arr":   un.Bool(false),
+				},
+			}
+		},
+	},
 }
 
 func TestOps(t *testing.T) {

--- a/uast/transformer/ops_test.go
+++ b/uast/transformer/ops_test.go
@@ -498,6 +498,88 @@ var opsCases = []struct {
 		},
 	},
 	{
+		// TODO(dennwc): this will only work when FieldDesc will support negative checks
+		skip: true,
+		name: "has fields",
+		inp: func() un.Node {
+			return un.Array{
+				un.Object{
+					u.KeyPos: un.Object{u.KeyStart: un.Int(1)},
+					"type":   un.String("ident"),
+					"name":   un.String("A"),
+				},
+				un.Object{
+					u.KeyPos: un.Object{u.KeyStart: un.Int(2)},
+					"type":   un.String("ident"),
+				},
+			}
+		},
+		src: Part("p", CheckObj(
+			HasFields{"name": false},
+			Obj{
+				"type": String("ident"),
+			},
+		)),
+		dst: Part("p", Obj{
+			"type": String("ident"),
+			"name": String("<empty>"),
+		}),
+		exp: func() un.Node {
+			return un.Array{
+				un.Object{
+					u.KeyPos: un.Object{u.KeyStart: un.Int(1)},
+					"type":   un.String("ident"),
+					"name":   un.String("A"),
+				},
+				un.Object{
+					u.KeyPos: un.Object{u.KeyStart: un.Int(2)},
+					"type":   un.String("ident"),
+					"name":   un.String("<empty>"),
+				},
+			}
+		},
+	},
+	{
+		name: "has fields root",
+		inp: func() un.Node {
+			return un.Array{
+				un.Object{
+					u.KeyPos: un.Object{u.KeyStart: un.Int(1)},
+					"type":   un.String("ident"),
+					"name":   un.String("A"),
+				},
+				un.Object{
+					u.KeyPos: un.Object{u.KeyStart: un.Int(2)},
+					"type":   un.String("ident"),
+				},
+			}
+		},
+		src: CheckObj(
+			HasFields{"name": false},
+			Part("p", Obj{
+				"type": String("ident"),
+			}),
+		),
+		dst: Part("p", Obj{
+			"type": String("ident"),
+			"name": String("<empty>"),
+		}),
+		exp: func() un.Node {
+			return un.Array{
+				un.Object{
+					u.KeyPos: un.Object{u.KeyStart: un.Int(1)},
+					"type":   un.String("ident"),
+					"name":   un.String("A"),
+				},
+				un.Object{
+					u.KeyPos: un.Object{u.KeyStart: un.Int(2)},
+					"type":   un.String("ident"),
+					"name":   un.String("<empty>"),
+				},
+			}
+		},
+	},
+	{
 		name: "append complex",
 		inp: func() un.Node {
 			return un.Object{


### PR DESCRIPTION
This is a combination of a few smaller changes required for C# driver.

First, it contains a change that breaks backward compatibility of one rarely used op for the sake of better naming. Previously `Any(sel)` operator was used to check if "any node in the array matches `sel`". PR renames this operator to `AnyElem` and defines a new function `Any()` that acts like "any node". This will allow us to replace a common pattern of `AnyNode(nil)` with `Any()`, which should be more readable.

The change won't break any drivers until they decide to update SDK version. I propose to just bump a minor version since the operation is very rare and the fix will only require to change the function name.

Next, PR defines a `HasFields` helper that can be used to check for presence or absence of specific object fields. Instead of `Not(Has{k1: Any()})` it's now possible to write `HasFields{k1: false}`.

To make the new operator useful, PR also defines a `CheckObj` helper that will properly propagate object-related information to the parent.

It also adds or clarifies documentation for related types.

The change may improve the performance of `AnnotateIfNoRoles` since it will be now able to propagate constraints to the root of the transform tree.