### PR TITLE
Support token extraction

### DIFF
--- a/assets/skeleton/bindata.go
+++ b/assets/skeleton/bindata.go
@@ -957,6 +957,7 @@ import (
 	"gopkg.in/bblfsh/sdk.v2/driver"
 	"gopkg.in/bblfsh/sdk.v2/driver/fixtures"
 	"gopkg.in/bblfsh/sdk.v2/driver/native"
+	"gopkg.in/bblfsh/sdk.v2/uast/transformer/positioner"
 )
 
 const projectRoot = "../../"
@@ -975,8 +976,8 @@ var Suite = &fixtures.Suite{
 			// TODO: list native types that should be converted to semantic UAST
 		},
 	},
-	Docker:fixtures.DockerConfig{
-		//Image:"image:tag", // TODO: specify a docker image with language runtime
+	VerifyTokens: []positioner.VerifyToken{
+	    // TODO: list nodes that needs to be checked for token correctness
 	},
 }
 
@@ -999,7 +1000,7 @@ func driverFixturesFixtures_testGoTpl() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "driver/fixtures/fixtures_test.go.tpl", size: 1133, mode: os.FileMode(420), modTime: time.Unix(1, 0)}
+	info := bindataFileInfo{name: "driver/fixtures/fixtures_test.go.tpl", size: 1192, mode: os.FileMode(420), modTime: time.Unix(1, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }

--- a/etc/skeleton/driver/fixtures/fixtures_test.go.tpl
+++ b/etc/skeleton/driver/fixtures/fixtures_test.go.tpl
@@ -8,6 +8,7 @@ import (
 	"gopkg.in/bblfsh/sdk.v2/driver"
 	"gopkg.in/bblfsh/sdk.v2/driver/fixtures"
 	"gopkg.in/bblfsh/sdk.v2/driver/native"
+	"gopkg.in/bblfsh/sdk.v2/uast/transformer/positioner"
 )
 
 const projectRoot = "../../"
@@ -26,8 +27,8 @@ var Suite = &fixtures.Suite{
 			// TODO: list native types that should be converted to semantic UAST
 		},
 	},
-	Docker:fixtures.DockerConfig{
-		//Image:"image:tag", // TODO: specify a docker image with language runtime
+	VerifyTokens: []positioner.VerifyToken{
+	    // TODO: list nodes that needs to be checked for token correctness
 	},
 }
 

--- a/uast/transformer/positioner/tokens.go
+++ b/uast/transformer/positioner/tokens.go
@@ -1,0 +1,166 @@
+package positioner
+
+import (
+	"fmt"
+
+	"gopkg.in/bblfsh/sdk.v2/uast"
+	"gopkg.in/bblfsh/sdk.v2/uast/nodes"
+	"gopkg.in/bblfsh/sdk.v2/uast/transformer"
+)
+
+var _ transformer.CodeTransformer = TokenFromSource{}
+
+// TokenFromSource extract node's token from the source code by using positional
+// information.
+type TokenFromSource struct {
+	// Key is the name of the token field to update. Uses uast.KeyToken, if not set.
+	// Only nodes with this field will be considered.
+	Key string
+	// Types is the list of node types that will be updated. Empty means all nodes.
+	Types []string
+}
+
+// OnCode implements transformer.CodeTransformer.
+func (t TokenFromSource) OnCode(code string) transformer.Transformer {
+	return &tokenFromSource{
+		tokenFilter: newTokenFilter(code, t.Key, t.Types),
+	}
+}
+
+func newTokenFilter(source string, key string, types []string) tokenFilter {
+	f := tokenFilter{
+		source: source, tokenKey: key,
+	}
+	if f.tokenKey == "" {
+		f.tokenKey = uast.KeyToken
+	}
+	if len(types) != 0 {
+		f.types = make(map[string]struct{})
+		for _, tp := range types {
+			f.types[tp] = struct{}{}
+		}
+	}
+	return f
+}
+
+type tokenFilter struct {
+	source   string
+	tokenKey string
+	types    map[string]struct{}
+}
+
+func (f *tokenFilter) filterObj(node nodes.Node) (nodes.Object, bool) {
+	obj, ok := node.(nodes.Object)
+	if !ok {
+		return nil, false
+	}
+	// nodes should already have a token
+	if _, ok = obj[f.tokenKey]; !ok {
+		return nil, false
+	}
+	// apply types filter
+	if f.types != nil {
+		typ, ok := obj[uast.KeyType].(nodes.String)
+		if !ok || typ == "" {
+			return nil, false
+		}
+		_, ok = f.types[string(typ)]
+		if !ok {
+			return nil, false
+		}
+	}
+	return obj, true
+}
+
+func (f *tokenFilter) tokenFromPos(obj nodes.Object) (string, bool, error) {
+	pos := uast.PositionsOf(obj)
+	if len(pos) == 0 {
+		return "", false, nil
+	}
+	start := pos.Start()
+	end := pos.End()
+	if start == nil || end == nil || !start.HasOffset() || !end.HasOffset() {
+		return "", false, nil
+	}
+	si, ei := start.Offset, end.Offset
+	if si > ei {
+		return "", false, fmt.Errorf("start offset is larger than an end offset: %v", pos)
+	} else if ei > uint32(len(f.source)) {
+		return "", false, fmt.Errorf("offset out of bounds: %v", pos)
+	}
+	// offset is given in bytes
+	token := f.source[si:ei]
+	return token, true, nil
+}
+
+type tokenFromSource struct {
+	tokenFilter
+}
+
+// Do implements transformer.Transformer. See TokenFromSource.
+func (t *tokenFromSource) Do(root nodes.Node) (nodes.Node, error) {
+	var last error
+	nodes.WalkPreOrder(root, func(node nodes.Node) bool {
+		if last != nil {
+			return false
+		}
+		obj, ok := t.filterObj(node)
+		if !ok {
+			// skip node, but recurse to children
+			return true
+		}
+		token, ok, err := t.tokenFromPos(obj)
+		if err != nil {
+			last = err
+			return false
+		} else if !ok {
+			return true // recurse
+		}
+		// it won't be nil, since we require both token and pos fields to exist
+		obj[t.tokenKey] = nodes.String(token)
+		return true
+	})
+	return root, last
+}
+
+// VerifyToken check that node's token matches its positional information.
+type VerifyToken struct {
+	// Key is the name of the token field to check. Uses uast.KeyToken, if not set.
+	Key string
+	// Types is the list of node types that will be checked. Empty means all nodes.
+	Types []string
+}
+
+func (t VerifyToken) Verify(code string, root nodes.Node) error {
+	f := newTokenFilter(code, t.Key, t.Types)
+
+	var last error
+	nodes.WalkPreOrder(root, func(node nodes.Node) bool {
+		if last != nil {
+			return false
+		}
+		obj, ok := f.filterObj(node)
+		if !ok {
+			// skip node, but recurse to children
+			return true
+		}
+		token1, ok := obj[t.Key].(nodes.String)
+		if !ok {
+			return true
+		}
+		token2, ok, err := f.tokenFromPos(obj)
+		if err != nil {
+			last = err
+			return false
+		} else if !ok {
+			return true
+		}
+		if string(token1) != token2 {
+			last = fmt.Errorf("wrong token for node %q: %q vs %q",
+				uast.TypeOf(obj), token1, token2)
+			return false
+		}
+		return true
+	})
+	return last
+}

--- a/uast/transformer/positioner/tokens_test.go
+++ b/uast/transformer/positioner/tokens_test.go
@@ -1,0 +1,163 @@
+package positioner
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"gopkg.in/bblfsh/sdk.v2/uast"
+	"gopkg.in/bblfsh/sdk.v2/uast/nodes"
+)
+
+func newPos(start, end int) nodes.Node {
+	return uast.Positions{
+		uast.KeyStart: {
+			Offset: uint32(start),
+			Line:   1,
+			Col:    uint32(1 + start),
+		},
+		uast.KeyEnd: {
+			Offset: uint32(end),
+			Line:   1,
+			Col:    uint32(1 + end),
+		},
+	}.ToObject()
+}
+
+func TestTokenFromSource(t *testing.T) {
+	testAst := nodes.Array{
+		nodes.Object{
+			uast.KeyType: nodes.String("test:Var"),
+			uast.KeyPos:  newPos(1, 13),
+			"Names": nodes.Array{
+				nodes.Object{
+					uast.KeyType:  nodes.String("test:Ident"),
+					uast.KeyToken: nodes.String(""),
+					uast.KeyPos:   newPos(5, 6),
+				},
+				nodes.Object{
+					uast.KeyType:  nodes.String("test:Ident"),
+					uast.KeyToken: nodes.String(""),
+					uast.KeyPos:   newPos(8, 9),
+				},
+			},
+			"Type": nodes.Object{
+				uast.KeyType:  nodes.String("test:Type"),
+				uast.KeyToken: nodes.String(""),
+				uast.KeyPos:   newPos(10, 13),
+				"Notes":       nodes.String(""),
+			},
+		},
+	}
+
+	var cases = []struct {
+		name     string
+		source   string
+		ast, exp nodes.Node
+		conf     TokenFromSource
+	}{
+		{
+			name:   "fix all",
+			source: " var a, b int",
+			conf:   TokenFromSource{}, // defaults
+			ast:    testAst,
+			exp: nodes.Array{
+				nodes.Object{
+					uast.KeyType: nodes.String("test:Var"),
+					uast.KeyPos:  newPos(1, 13),
+					"Names": nodes.Array{
+						nodes.Object{
+							uast.KeyType:  nodes.String("test:Ident"),
+							uast.KeyToken: nodes.String("a"),
+							uast.KeyPos:   newPos(5, 6),
+						},
+						nodes.Object{
+							uast.KeyType:  nodes.String("test:Ident"),
+							uast.KeyToken: nodes.String("b"),
+							uast.KeyPos:   newPos(8, 9),
+						},
+					},
+					"Type": nodes.Object{
+						uast.KeyType:  nodes.String("test:Type"),
+						uast.KeyToken: nodes.String("int"),
+						uast.KeyPos:   newPos(10, 13),
+						"Notes":       nodes.String(""),
+					},
+				},
+			},
+		},
+		{
+			name:   "only type",
+			source: " var a, b int",
+			conf: TokenFromSource{
+				Types: []string{"test:Type"},
+			},
+			ast: testAst,
+			exp: nodes.Array{
+				nodes.Object{
+					uast.KeyType: nodes.String("test:Var"),
+					uast.KeyPos:  newPos(1, 13),
+					"Names": nodes.Array{
+						nodes.Object{
+							uast.KeyType:  nodes.String("test:Ident"),
+							uast.KeyToken: nodes.String(""),
+							uast.KeyPos:   newPos(5, 6),
+						},
+						nodes.Object{
+							uast.KeyType:  nodes.String("test:Ident"),
+							uast.KeyToken: nodes.String(""),
+							uast.KeyPos:   newPos(8, 9),
+						},
+					},
+					"Type": nodes.Object{
+						uast.KeyType:  nodes.String("test:Type"),
+						uast.KeyToken: nodes.String("int"),
+						uast.KeyPos:   newPos(10, 13),
+						"Notes":       nodes.String(""),
+					},
+				},
+			},
+		},
+		{
+			name:   "specific field",
+			source: " var a, b int",
+			conf: TokenFromSource{
+				Key: "Notes",
+			},
+			ast: testAst,
+			exp: nodes.Array{
+				nodes.Object{
+					uast.KeyType: nodes.String("test:Var"),
+					uast.KeyPos:  newPos(1, 13),
+					"Names": nodes.Array{
+						nodes.Object{
+							uast.KeyType:  nodes.String("test:Ident"),
+							uast.KeyToken: nodes.String(""),
+							uast.KeyPos:   newPos(5, 6),
+						},
+						nodes.Object{
+							uast.KeyType:  nodes.String("test:Ident"),
+							uast.KeyToken: nodes.String(""),
+							uast.KeyPos:   newPos(8, 9),
+						},
+					},
+					"Type": nodes.Object{
+						uast.KeyType:  nodes.String("test:Type"),
+						uast.KeyToken: nodes.String(""),
+						uast.KeyPos:   newPos(10, 13),
+						"Notes":       nodes.String("int"),
+					},
+				},
+			},
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			root := c.ast
+			tr := c.conf.OnCode(c.source)
+			got, err := tr.Do(root.Clone())
+			require.NoError(t, err)
+			require.Equal(t, c.exp, got)
+		})
+	}
+}


### PR DESCRIPTION
Changes in this PR enable the token extraction based on the source file and positional information. Needed for C# driver. And it can be used to improve other drivers as well.

- Implement a new `CodeTransformer` that uses positional offsets to update the token of AST nodes.
- Allow checking that positional information matches the token during fixtures tests.
- Add a new code-assisted transformation stage after `Preprocess` stage.
- Document the AST transformation pipeline.

This change also adds a deprecation note to the `Code` transformation stage. It was documented to run on the raw AST (`Native` stage), but it was always running at the end of the pipeline after all annotations were executed.

Drivers rely on real behavior, but there is no reason to run this stage so late in the pipeline. In fact, this was the only stage that has access to the source code. And because it runs so late, it's useless for fixing tokens and positional information - annotation will observe broken or empty tokens. For example, `Normalize` stage (aka Semantic mode) will need correct tokens to unescape them, and it's not possible with the late `Code` stage.

Instead, the new `PreprocessCode` stage was defined. It will run after `Preprocess` stage to be able to see the fixes in the native AST, as well as normalized positional info. And the stage will run before any annotations, so they will be able to see correct positions and/or tokens in the AST. 