### PR TITLE
Split comments

### DIFF
--- a/uast/transformer/semantic_test.go
+++ b/uast/transformer/semantic_test.go
@@ -16,8 +16,8 @@ func TestComment(t *testing.T) {
 			name: "one line",
 			text: "// some text",
 			exp: commentElems{
-				Tokens: [2]string{"//", ""},
-				Pref:   " ",
+				StartToken: "//", EndToken: "",
+				Prefix: " ",
 				Text:   "some text",
 			},
 		},
@@ -25,8 +25,8 @@ func TestComment(t *testing.T) {
 			name: "new line",
 			text: "// some text\n",
 			exp: commentElems{
-				Tokens: [2]string{"//", ""},
-				Pref:   " ", Suff: "\n",
+				StartToken: "//", EndToken: "",
+				Prefix: " ", Suffix: "\n",
 				Text: "some text",
 			},
 		},
@@ -34,8 +34,8 @@ func TestComment(t *testing.T) {
 			name: "multi-line single",
 			text: "/* some text */",
 			exp: commentElems{
-				Tokens: [2]string{"/*", "*/"},
-				Pref:   " ", Suff: " ",
+				StartToken: "/*", EndToken: "*/",
+				Prefix: " ", Suffix: " ",
 				Text: "some text",
 			},
 		},
@@ -45,8 +45,8 @@ func TestComment(t *testing.T) {
 	some text
 */`,
 			exp: commentElems{
-				Tokens: [2]string{"/*", "*/"},
-				Pref:   "\n\t", Suff: "\n",
+				StartToken: "/*", EndToken: "*/",
+				Prefix: "\n\t", Suffix: "\n",
 				Text: "some text",
 			},
 		},
@@ -57,8 +57,8 @@ func TestComment(t *testing.T) {
 	line two
 */`,
 			exp: commentElems{
-				Tokens: [2]string{"/*", "*/"},
-				Pref:   "\n\t", Tab: "\t", Suff: "\n",
+				StartToken: "/*", EndToken: "*/",
+				Prefix: "\n\t", Indent: "\t", Suffix: "\n",
 				Text: "some text\nline two",
 			},
 		},
@@ -70,8 +70,8 @@ func TestComment(t *testing.T) {
  * line three
 */`,
 			exp: commentElems{
-				Tokens: [2]string{"/*", "*/"},
-				Pref:   "\n * ", Tab: " * ", Suff: "\n",
+				StartToken: "/*", EndToken: "*/",
+				Prefix: "\n * ", Indent: " * ", Suffix: "\n",
 				Text: "some text\nline two\nline three",
 			},
 		},
@@ -80,8 +80,8 @@ func TestComment(t *testing.T) {
 			text: `// some text
 // line two`,
 			exp: commentElems{
-				Tokens: [2]string{"//", ""},
-				Pref:   " ", Tab: "// ", Suff: "",
+				StartToken: "//", EndToken: "",
+				Prefix: " ", Indent: "// ", Suffix: "",
 				Text: "some text\nline two",
 			},
 		},
@@ -93,8 +93,8 @@ func TestComment(t *testing.T) {
  * line three
 */`,
 			exp: commentElems{
-				Tokens: [2]string{"/*", "*/"},
-				Pref:   "\n * ", Tab: " * ", Suff: "\n",
+				StartToken: "/*", EndToken: "*/",
+				Prefix: "\n * ", Indent: " * ", Suffix: "\n",
 				Text: "some text\n  line two\nline three",
 			},
 		},
@@ -106,15 +106,18 @@ func TestComment(t *testing.T) {
  * line three
 */`,
 			exp: commentElems{
-				Tokens: [2]string{"/*", "*/"},
-				Pref:   "\n * ", Tab: " ", Suff: "\n",
+				StartToken: "/*", EndToken: "*/",
+				Prefix: "\n * ", Indent: " ", Suffix: "\n",
 				Text: "some text\n  line two\n* line three",
 			},
 		},
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
-			v := commentElems{Tokens: c.exp.Tokens}
+			v := commentElems{
+				StartToken: c.exp.StartToken,
+				EndToken:   c.exp.EndToken,
+			}
 			if !v.Split(c.text) {
 				t.Error("split failed")
 			}

--- a/uast/transformer/semantic_test.go
+++ b/uast/transformer/semantic_test.go
@@ -58,9 +58,8 @@ func TestComment(t *testing.T) {
 */`,
 			exp: commentElems{
 				Tokens: [2]string{"/*", "*/"},
-				Pref:   "\n\t", Suff: "\n",
-				// TODO(dennwc): we need to split Tab
-				Text: "some text\n\tline two",
+				Pref:   "\n\t", Tab: "\t", Suff: "\n",
+				Text: "some text\nline two",
 			},
 		},
 		{
@@ -68,12 +67,12 @@ func TestComment(t *testing.T) {
 			text: `/*
  * some text
  * line two
+ * line three
 */`,
 			exp: commentElems{
 				Tokens: [2]string{"/*", "*/"},
-				// TODO(dennwc): we need to split Tab
-				Pref: "\n * ", Suff: "\n",
-				Text: "some text\n * line two",
+				Pref:   "\n * ", Tab: " * ", Suff: "\n",
+				Text: "some text\nline two\nline three",
 			},
 		},
 		{
@@ -82,9 +81,34 @@ func TestComment(t *testing.T) {
 // line two`,
 			exp: commentElems{
 				Tokens: [2]string{"//", ""},
-				// TODO(dennwc): we need to split Tab
-				Pref: " ", Suff: "",
-				Text: "some text\n// line two",
+				Pref:   " ", Tab: "// ", Suff: "",
+				Text: "some text\nline two",
+			},
+		},
+		{
+			name: "stylistic inconsistent",
+			text: `/*
+ * some text
+ *   line two
+ * line three
+*/`,
+			exp: commentElems{
+				Tokens: [2]string{"/*", "*/"},
+				Pref:   "\n * ", Tab: " * ", Suff: "\n",
+				Text: "some text\n  line two\nline three",
+			},
+		},
+		{
+			name: "inconsistent",
+			text: `/*
+ * some text
+   line two
+ * line three
+*/`,
+			exp: commentElems{
+				Tokens: [2]string{"/*", "*/"},
+				Pref:   "\n * ", Tab: " ", Suff: "\n",
+				Text: "some text\n  line two\n* line three",
 			},
 		},
 	}

--- a/uast/transformer/semantic_test.go
+++ b/uast/transformer/semantic_test.go
@@ -1,0 +1,101 @@
+package transformer
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestComment(t *testing.T) {
+	var cases = []struct {
+		name string
+		text string
+		exp  commentElems
+	}{
+		{
+			name: "one line",
+			text: "// some text",
+			exp: commentElems{
+				Tokens: [2]string{"//", ""},
+				Pref:   " ",
+				Text:   "some text",
+			},
+		},
+		{
+			name: "new line",
+			text: "// some text\n",
+			exp: commentElems{
+				Tokens: [2]string{"//", ""},
+				Pref:   " ", Suff: "\n",
+				Text: "some text",
+			},
+		},
+		{
+			name: "multi-line single",
+			text: "/* some text */",
+			exp: commentElems{
+				Tokens: [2]string{"/*", "*/"},
+				Pref:   " ", Suff: " ",
+				Text: "some text",
+			},
+		},
+		{
+			name: "multi-line new line",
+			text: `/*
+	some text
+*/`,
+			exp: commentElems{
+				Tokens: [2]string{"/*", "*/"},
+				Pref:   "\n\t", Suff: "\n",
+				Text: "some text",
+			},
+		},
+		{
+			name: "multi-line",
+			text: `/*
+	some text
+	line two
+*/`,
+			exp: commentElems{
+				Tokens: [2]string{"/*", "*/"},
+				Pref:   "\n\t", Suff: "\n",
+				// TODO(dennwc): we need to split Tab
+				Text: "some text\n\tline two",
+			},
+		},
+		{
+			name: "stylistic",
+			text: `/*
+ * some text
+ * line two
+*/`,
+			exp: commentElems{
+				Tokens: [2]string{"/*", "*/"},
+				// TODO(dennwc): we need to split Tab
+				Pref: "\n * ", Suff: "\n",
+				Text: "some text\n * line two",
+			},
+		},
+		{
+			name: "multiple single line",
+			text: `// some text
+// line two`,
+			exp: commentElems{
+				Tokens: [2]string{"//", ""},
+				// TODO(dennwc): we need to split Tab
+				Pref: " ", Suff: "",
+				Text: "some text\n// line two",
+			},
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			v := commentElems{Tokens: c.exp.Tokens}
+			if !v.Split(c.text) {
+				t.Error("split failed")
+			}
+			require.Equal(t, c.exp, v)
+			require.Equal(t, c.text, v.Join())
+		})
+	}
+}

--- a/uast/uast.go
+++ b/uast/uast.go
@@ -406,6 +406,8 @@ type Comment struct {
 	//     */
 	//
 	//    the " *" before the comment text is considered a tab
+	//
+	// TODO(dennwc): rename to Indent?
 	Tab string `json:"Tab"`
 }
 


### PR DESCRIPTION
SDK defines a `uast.Comment` with multiple text components, namely `Prefix`, `Tab`, `Text` and `Suffix`. But to save some time we haven't implemented parsing of `Tab`.

This change implements `Tag` parsing properly. It also fixes problems with tab character detection in `Prefix` and `Suffix`.

This will change the way how `Comment` nodes are populated in Semantic mode. It only aligns the AST with the documented behavior though, so should be considered as a fix.