### PR TITLE
Allow to use PreprocessCode stage

### DIFF
--- a/assets/skeleton/bindata.go
+++ b/assets/skeleton/bindata.go
@@ -1147,6 +1147,10 @@ var Preprocessors = []Mapping{
 	}.Mapping(),
 }
 
+// PreprocessCode is a preprocessor stage that can use the source code to
+// fix tokens and positional information.
+var PreprocessCode = []CodeTransformer{}
+
 // Normalizers is the main block of normalization rules to convert native AST to semantic UAST.
 var Normalizers = []Mapping{}
 `)
@@ -1161,7 +1165,7 @@ func driverNormalizerNormalizerGo() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "driver/normalizer/normalizer.go", size: 951, mode: os.FileMode(420), modTime: time.Unix(1, 0)}
+	info := bindataFileInfo{name: "driver/normalizer/normalizer.go", size: 1109, mode: os.FileMode(420), modTime: time.Unix(1, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -1171,11 +1175,12 @@ var _driverNormalizerTransformsGoTpl = []byte(`package normalizer
 import "gopkg.in/bblfsh/sdk.v2/driver"
 
 var Transforms = driver.Transforms{
-	Namespace:   "{{.Manifest.Language}}",
-	Preprocess:  Preprocess,
-	Normalize:   Normalize,
-	Annotations: Native,
-	Code:        Code,
+	Namespace:      "{{.Manifest.Language}}",
+	Preprocess:     Preprocess,
+	PreprocessCode: PreprocessCode,
+	Normalize:      Normalize,
+	Annotations:    Native,
+	Code:           Code,
 }
 `)
 
@@ -1189,7 +1194,7 @@ func driverNormalizerTransformsGoTpl() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "driver/normalizer/transforms.go.tpl", size: 231, mode: os.FileMode(420), modTime: time.Unix(1, 0)}
+	info := bindataFileInfo{name: "driver/normalizer/transforms.go.tpl", size: 279, mode: os.FileMode(420), modTime: time.Unix(1, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }

--- a/etc/skeleton/driver/normalizer/normalizer.go
+++ b/etc/skeleton/driver/normalizer/normalizer.go
@@ -32,5 +32,9 @@ var Preprocessors = []Mapping{
 	}.Mapping(),
 }
 
+// PreprocessCode is a preprocessor stage that can use the source code to
+// fix tokens and positional information.
+var PreprocessCode = []CodeTransformer{}
+
 // Normalizers is the main block of normalization rules to convert native AST to semantic UAST.
 var Normalizers = []Mapping{}

--- a/etc/skeleton/driver/normalizer/transforms.go.tpl
+++ b/etc/skeleton/driver/normalizer/transforms.go.tpl
@@ -3,9 +3,10 @@ package normalizer
 import "gopkg.in/bblfsh/sdk.v2/driver"
 
 var Transforms = driver.Transforms{
-	Namespace:   "{{.Manifest.Language}}",
-	Preprocess:  Preprocess,
-	Normalize:   Normalize,
-	Annotations: Native,
-	Code:        Code,
+	Namespace:      "{{.Manifest.Language}}",
+	Preprocess:     Preprocess,
+	PreprocessCode: PreprocessCode,
+	Normalize:      Normalize,
+	Annotations:    Native,
+	Code:           Code,
 }


### PR DESCRIPTION
During the last update of SDK I forgot to update managed skeleton files for drivers. Because of this, it's impossible to use the new `PreprocessCode` stage introduced in the new version (see CI failure in https://github.com/bblfsh/csharp-driver/pull/14).

PR updates skeleton files to allow the new stage.

This, however, will have some consequences for other drivers. Once an SDK is updated, it will include a new version of managed `transforms.go` file, that references a `PreprocessCode` global, which won't be available in old drivers. The fix is simple - include an empty stage with this name.

Another option may be to remove `transforms.go` from managed files. But it was added to this list on purpose. Each time SDK changes the transformation pipeline, the change should be considered by the driver's author. So I don't consider this a good option.

Signed-off-by: Denys Smirnov <denys@sourced.tech>