### PR TITLE
More robust comment string parsing

### DIFF
--- a/uast/transformer/semantic.go
+++ b/uast/transformer/semantic.go
@@ -162,7 +162,7 @@ func (c *commentElems) isTab(r rune) bool {
 
 func (c *commentElems) Split(text string) bool {
 	if c.DoTrim {
-		text = strings.TrimLeftFunc(text, func(r rune) bool {
+		text = strings.TrimLeftFunc(text, unicode.IsSpace)
 			return unicode.IsSpace(r)
 		})
 	}

--- a/uast/transformer/semantic.go
+++ b/uast/transformer/semantic.go
@@ -163,8 +163,6 @@ func (c *commentElems) isTab(r rune) bool {
 func (c *commentElems) Split(text string) bool {
 	if c.DoTrim {
 		text = strings.TrimLeftFunc(text, unicode.IsSpace)
-			return unicode.IsSpace(r)
-		})
 	}
 
 	if !strings.HasPrefix(text, c.StartToken) || !strings.HasSuffix(text, c.EndToken) {


### PR DESCRIPTION
- Checks values returned by Index functions for -1 (had a case where it was -1, check failing CI in until this is merged in bblfsh/python-driver/pull/176).
- Trims the text before checking if the prefix and suffix exist with `HasPrefix` and `HasSuffix` to avoid cases where the language can give a wrong position for the start of the comment (or only the line) like happens with Python with some comments where it gives all the whitespace before if they're on their own line and indented.

Signed-off-by: Juanjo Alvarez <juanjo@sourced.tech>