### PR TITLE
Fix field usage validation when joining objects

### DIFF
--- a/uast/transformer/errors.go
+++ b/uast/transformer/errors.go
@@ -5,6 +5,9 @@ import (
 	"fmt"
 
 	"gopkg.in/src-d/go-errors.v1"
+
+	"gopkg.in/bblfsh/sdk.v2/uast"
+	"gopkg.in/bblfsh/sdk.v2/uast/nodes"
 )
 
 var (
@@ -44,7 +47,9 @@ var (
 	// ErrUnusedField is returned when a transformation is not defined as partial, but does not process a specific key
 	// found in object. This usually means that an AST has a field that is not covered by transformation code and it
 	// should be added to the mapping.
-	ErrUnusedField = errors.NewKind("unused field(s): %v")
+	//
+	// Use NewErrUnusedField for constructing this error.
+	ErrUnusedField = errors.NewKind("unused field(s) on node %v: %v")
 	// ErrDuplicateField is returned when trying to create a Fields definition with two items with the same name.
 	ErrDuplicateField = errors.NewKind("duplicate field: %v")
 	// ErrUndefinedField is returned when trying to create an object with a field that is not defined in the type spec.
@@ -88,4 +93,21 @@ func (e *MultiError) Error() string {
 		fmt.Fprintf(buf, "\t%v\n", err)
 	}
 	return buf.String()
+}
+
+// NewErrUnusedField is a helper for creating ErrUnusedField.
+//
+// It will include a short type information for the node to simplify debugging.
+func NewErrUnusedField(n nodes.Object, fields []string) error {
+	var t interface{}
+	if typ, _ := n[uast.KeyType].(nodes.String); typ != "" {
+		t = typ
+	} else {
+		t = n.Keys()
+	}
+	var f interface{} = fields
+	if len(fields) == 1 {
+		f = fields[0]
+	}
+	return ErrUnusedField.New(t, f)
 }

--- a/uast/transformer/errors.go
+++ b/uast/transformer/errors.go
@@ -44,7 +44,7 @@ var (
 	// ErrUnusedField is returned when a transformation is not defined as partial, but does not process a specific key
 	// found in object. This usually means that an AST has a field that is not covered by transformation code and it
 	// should be added to the mapping.
-	ErrUnusedField = errors.NewKind("field was not used: %v")
+	ErrUnusedField = errors.NewKind("unused field(s): %v")
 	// ErrDuplicateField is returned when trying to create a Fields definition with two items with the same name.
 	ErrDuplicateField = errors.NewKind("duplicate field: %v")
 	// ErrUndefinedField is returned when trying to create an object with a field that is not defined in the type spec.

--- a/uast/transformer/ops.go
+++ b/uast/transformer/ops.go
@@ -583,7 +583,7 @@ func (op *opObjJoin) CheckObj(st *State, n nodes.Object) (bool, error) {
 			return false, err
 		}
 	} else if len(n) != 0 {
-		return false, ErrUnusedField.New(n.Keys())
+		return false, NewErrUnusedField(src, n.Keys())
 	}
 	return true, nil
 }
@@ -821,7 +821,7 @@ func (o Fields) CheckObj(st *State, n nodes.Object) (bool, error) {
 		set, _ := o.Fields() // TODO: optimize
 		for k := range n {
 			if _, ok := set[k]; !ok {
-				return false, ErrUnusedField.New(k)
+				return false, NewErrUnusedField(n, []string{k})
 			}
 		}
 	}

--- a/uast/transformer/ops.go
+++ b/uast/transformer/ops.go
@@ -335,7 +335,9 @@ type ObjectSel interface {
 	Sel
 	// Fields returns a map of field names that will be processed by this operation.
 	// The flag in the map indicates if the field is required.
-	// False bool value returned as a second argument indicates that implementation will process all fields.
+	//
+	// Returning true as a second argument indicates that the operation will always
+	// use all fields. Returning false means that an operation is partial.
 	Fields() (FieldDescs, bool)
 
 	CheckObj(st *State, n nodes.Object) (bool, error)
@@ -580,6 +582,8 @@ func (op *opObjJoin) CheckObj(st *State, n nodes.Object) (bool, error) {
 		if ok, err := op.partial.CheckObj(st, n); err != nil || !ok {
 			return false, err
 		}
+	} else if len(n) != 0 {
+		return false, ErrUnusedField.New(n.Keys())
 	}
 	return true, nil
 }

--- a/uast/transformer/ops_test.go
+++ b/uast/transformer/ops_test.go
@@ -289,6 +289,122 @@ var opsCases = []struct {
 		src: Each("objs", Var("part")),
 	},
 	{
+		name: "field missing (fields)",
+		inp: func() un.Node {
+			return un.Object{
+				"t": un.String("a"),
+				"v": nil,
+			}
+		},
+		src: Fields{
+			{Name: "t", Op: String("a")},
+		},
+		err: ErrUnusedField,
+	},
+	{
+		name: "field missing (obj)",
+		inp: func() un.Node {
+			return un.Object{
+				"t": un.String("a"),
+				"v": nil,
+			}
+		},
+		src: Obj{
+			"t": String("a"),
+		},
+		err: ErrUnusedField,
+	},
+	{
+		name: "join obj",
+		inp: func() un.Node {
+			return un.Object{
+				"t":  un.String("a"),
+				"v1": un.Int(1),
+				"v2": un.Int(2),
+			}
+		},
+		src: JoinObj(
+			Obj{
+				"t": String("a"),
+			},
+			Obj{
+				"v1": Int(1),
+				"v2": Int(2),
+			},
+		),
+		dst: JoinObj(
+			Obj{
+				"t":  String("a"),
+				"k1": Int(3),
+			},
+			Obj{
+				"k2": Int(4),
+			},
+		),
+		exp: func() un.Node {
+			return un.Object{
+				"t":  un.String("a"),
+				"k1": un.Int(3),
+				"k2": un.Int(4),
+			}
+		},
+	},
+	{
+		name: "join obj unused",
+		inp: func() un.Node {
+			return un.Object{
+				"t":  un.String("a"),
+				"v1": un.Int(1),
+				"v2": un.Int(2),
+			}
+		},
+		src: JoinObj(
+			Obj{
+				"t": String("a"),
+			},
+			Obj{
+				"v1": Int(1),
+			},
+		),
+		err: ErrUnusedField,
+	},
+	{
+		name: "join obj unused part",
+		inp: func() un.Node {
+			return un.Object{
+				"t":  un.String("a"),
+				"v1": un.Int(1),
+				"v2": un.Int(2),
+			}
+		},
+		src: JoinObj(
+			Obj{
+				"t": String("a"),
+			},
+			Part("part", Obj{
+				"v1": Int(1),
+			}),
+		),
+		dst: JoinObj(
+			Obj{
+				"t": String("a"),
+				"m": Var("part"),
+			},
+			Obj{
+				"k2": Int(4),
+			},
+		),
+		exp: func() un.Node {
+			return un.Object{
+				"t": un.String("a"),
+				"m": un.Object{
+					"v2": un.Int(2),
+				},
+				"k2": un.Int(4),
+			}
+		},
+	},
+	{
 		name: "optional field",
 		inp: func() un.Node {
 			return un.Object{

--- a/uast/transformer/transformer_test.go
+++ b/uast/transformer/transformer_test.go
@@ -231,7 +231,7 @@ var mappingCases = []struct {
 				"type": String("B"),
 			},
 		)),
-		err: "check: field was not used: name",
+		err: "check: unused field(s): name",
 	},
 	{
 		name: "variable undefined",

--- a/uast/transformer/transformer_test.go
+++ b/uast/transformer/transformer_test.go
@@ -231,7 +231,7 @@ var mappingCases = []struct {
 				"type": String("B"),
 			},
 		)),
-		err: "check: unused field(s): name",
+		err: "check: unused field(s) on node [name type]: name",
 	},
 	{
 		name: "variable undefined",


### PR DESCRIPTION
Fix a DSL validation bug discovered while working on C# driver. Also added more tests for similar cases.

As mentioned previously, the bug affected the DSL validation and may be a cause of dropped fields, since it gives no error for transforms that forget to specify a specific field that exists in the specific AST node type.

This may break existing drivers that exploited the bug, bypassing the validation by mistake.

Signed-off-by: Denys Smirnov <denys@sourced.tech>