### PR TITLE
Fix SDK test to run on non-linux os

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,8 +34,8 @@ at `$GOPATH/bin/`.
 
 ### Contribute
 
-The SDK provides many templates for language drivers.
-These templates are converted to Go code that ends up in both `bblfsh-sdk` and `bblfsh-sdk-tools` automatically. Use `make` convert templates to code:
+The SDK provides scaffolding templates for creating a new language driver.
+These templates are converted to Go code that ends up in `bblfsh-sdk` tool. Use `make` to update these templates:
 
 ```bash
 $ make
@@ -150,6 +150,26 @@ For further details of how to construct a language driver,
 take a look at [Implementing the driver](https://doc.bblf.sh/driver/sdk.html#implementing-the-driver)
 section in documentation.
 
+### Testing the driver
+
+`bbflsh-sdk` also includes a testing framework for a driver.
+In order to run test for a particular dirver, change to it's directory and run:
+
+```bash
+$ bblfsh-sdk test
+```
+
+This will:
+ - compile a "test binary" that parses content of the `./fixtures` directory of the driver
+ - create a docker image with all dependencies, native driver and a test binary
+ - run this test binary inside a Docker container, using that image
+
+ Overall, SDK supports 3 different kind of tests for a driver:
+  - UnitTests, parsing content of `./fixtures` and applying UAST transformations. Described above.
+  - Integration tests, using content of `./fixtures/_integration*`
+  - Benchmarks, using content of `./fixtures/bench_*`
+
+First two always run, benchmarks are only triggered by `bblfsh-sdk test --bench`.
 
 ## License
 

--- a/cmd/bblfsh-sdk/cmd/build.go
+++ b/cmd/bblfsh-sdk/cmd/build.go
@@ -32,8 +32,8 @@ func (c *BuildCommand) Execute(args []string) error {
 
 const TestCommandDescription = "tests the driver using fixtures"
 
-// TestCommand will compare gold annotations in driver ./fixtures to the
-// ones produced by
+// TestCommand compares "gold" annotations from driver's ./fixtures directory
+// to the ones produced by bblfsh now.
 type TestCommand struct {
 	cmd.Command
 	Bblfshd string `long:"bblfshd" description:"bblfshd version to test with"`

--- a/cmd/bblfsh-sdk/cmd/build.go
+++ b/cmd/bblfsh-sdk/cmd/build.go
@@ -32,6 +32,8 @@ func (c *BuildCommand) Execute(args []string) error {
 
 const TestCommandDescription = "tests the driver using fixtures"
 
+// TestCommand will compare gold annotations in driver ./fixtures to the
+// ones produced by
 type TestCommand struct {
 	cmd.Command
 	Bblfshd string `long:"bblfshd" description:"bblfshd version to test with"`

--- a/driver/fixtures/docker.go
+++ b/driver/fixtures/docker.go
@@ -80,7 +80,10 @@ func (s *Suite) genDockerfile(t testing.TB, dir string) {
 }
 
 func compileTest(t testing.TB, path, dst string) {
-	out, err := exec.Command("go", "test", "-c", "-o", dst, path).CombinedOutput()
+	cmd := exec.Command("go", "test", "-c", "-o", dst, path)
+	cmd.Env = os.Environ()
+	cmd.Env = append(cmd.Env, "GOOS=linux")
+	out, err := cmd.CombinedOutput()
 	require.NoError(t, err, "failed to compile tests; output:\n%s", out)
 }
 

--- a/driver/fixtures/fixtures.go
+++ b/driver/fixtures/fixtures.go
@@ -27,7 +27,7 @@ const Dir = "fixtures"
 const (
 	syntaxErrTestName = "_syntax_error"
 	maxParseErrors    = 3
-	parseTimeout      = time.Minute / 30
+	parseTimeout      = 5 * time.Minute
 )
 
 type SemanticConfig struct {

--- a/driver/fixtures/fixtures.go
+++ b/driver/fixtures/fixtures.go
@@ -27,7 +27,7 @@ const Dir = "fixtures"
 const (
 	syntaxErrTestName = "_syntax_error"
 	maxParseErrors    = 3
-	parseTimeout      = 5 * time.Minute
+	parseTimeout      = time.Minute
 )
 
 type SemanticConfig struct {


### PR DESCRIPTION
This change consists of
 - documentation for `bblfhs-sdk test`
 - change default test timeout to 1 min
 - always compile `fixtures.test` binary for linux OS, so it could always be run inside a container