### PR TITLE
Add few node helpers

### DIFF
--- a/uast/nodes/node.go
+++ b/uast/nodes/node.go
@@ -948,3 +948,29 @@ func UniqueKey(n Node) Comparable {
 		return unkPtr(ptr)
 	}
 }
+
+// ChildrenCount reports the number of immediate children of n. If n is an Array this is
+// the length of the array. If n is an Object, each object in a field of n counts as
+// one child and each array is counted as its length.
+func ChildrenCount(n Node) int {
+	switch n := n.(type) {
+	case nil:
+		return 0
+	case Value:
+		return 0
+	case Array:
+		return len(n)
+	case Object:
+		c := 0
+		for _, v := range n {
+			switch v := v.(type) {
+			case Object:
+				c++
+			case Array:
+				c += len(v)
+			}
+		}
+		return c
+	}
+	return 0
+}

--- a/uast/nodes/node_test.go
+++ b/uast/nodes/node_test.go
@@ -38,6 +38,50 @@ func TestClone(t *testing.T) {
 	}, arr)
 }
 
+func TestChildrenCount(t *testing.T) {
+	var cases = []struct {
+		name string
+		node Node
+		exp  int
+	}{
+		{
+			name: "value",
+			node: Int(3),
+			exp:  0,
+		},
+		{
+			name: "array",
+			node: Array{
+				Int(1),
+				Array{Int(2), Int(3)},
+				Object{
+					"a": Int(1),
+					"b": Int(2),
+				},
+			},
+			exp: 3,
+		},
+		{
+			name: "object",
+			node: Object{
+				"k1":  Int(1),
+				"k2":  Int(2),
+				"arr": Array{Int(2), Int(3)},
+				"obj": Object{
+					"a": Int(1),
+					"b": Int(2),
+				},
+			},
+			exp: 3,
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			require.Equal(t, c.exp, ChildrenCount(c.node))
+		})
+	}
+}
+
 func TestApply(t *testing.T) {
 	o1 := Object{"v": Int(1)}
 	o2 := Object{"k": o1, "v": Int(2)}


### PR DESCRIPTION
Add a `ChildrenCount` helper (requested by https://github.com/bblfsh/client-go/issues/109) and relax argument constraints for `PositionsOf`, `RolesOf` and `TokenOf` (see https://github.com/bblfsh/client-go/issues/100).

Fixes https://github.com/bblfsh/client-go/issues/109.