### PR TITLE
Optimize DSL

### DIFF
--- a/uast/nodes/node.go
+++ b/uast/nodes/node.go
@@ -45,20 +45,30 @@ func Equal(n1, n2 External) bool {
 			return n1 == n2
 		}
 	case Object:
-		n2, ok := n2.(Object)
-		if !ok || len(n1) != len(n2) {
+		if n2, ok := n2.(Object); ok {
+			if len(n1) != len(n2) {
+				return false
+			}
+			if pointerOf(n1) == pointerOf(n2) {
+				return true
+			}
+			return n1.EqualObject(n2)
+		}
+		if _, ok := n2.(Node); ok {
 			return false
 		}
-		if pointerOf(n1) == pointerOf(n2) {
-			return true
-		}
-		return n1.EqualObject(n2)
+		return n1.Equal(n2)
 	case Array:
-		n2, ok := n2.(Array)
-		if !ok || len(n1) != len(n2) {
+		if n2, ok := n2.(Array); ok {
+			if len(n1) != len(n2) {
+				return false
+			}
+			return len(n1) == 0 || &n1[0] == &n2[0] || n1.EqualArray(n2)
+		}
+		if _, ok := n2.(Node); ok {
 			return false
 		}
-		return len(n1) == 0 || &n1[0] == &n2[0] || n1.EqualArray(n2)
+		return n1.Equal(n2)
 	default:
 		if Same(n1, n2) {
 			return true
@@ -972,7 +982,7 @@ func Same(n1, n2 External) bool {
 }
 
 // pointerOf returns a Go pointer for Node that is a reference type (Arrays and Objects).
-func pointerOf(n Node) uintptr {
+func pointerOf(n interface{}) uintptr {
 	if n == nil {
 		return 0
 	}

--- a/uast/nodes/node.go
+++ b/uast/nodes/node.go
@@ -13,8 +13,56 @@ const applySort = false
 // Equal compares two subtrees.
 // Equality is checked by value (deep), not by reference.
 func Equal(n1, n2 External) bool {
-	if Same(n1, n2) {
+	if n1 == nil && n2 == nil {
 		return true
+	} else if n1 == nil || n2 == nil {
+		return false
+	}
+	switch n1 := n1.(type) {
+	case String:
+		n2, ok := n2.(String)
+		if ok {
+			return n1 == n2
+		}
+	case Int:
+		n2, ok := n2.(Int)
+		if ok {
+			return n1 == n2
+		}
+	case Uint:
+		n2, ok := n2.(Uint)
+		if ok {
+			return n1 == n2
+		}
+	case Bool:
+		n2, ok := n2.(Bool)
+		if ok {
+			return n1 == n2
+		}
+	case Float:
+		n2, ok := n2.(Float)
+		if ok {
+			return n1 == n2
+		}
+	case Object:
+		n2, ok := n2.(Object)
+		if !ok || len(n1) != len(n2) {
+			return false
+		}
+		if pointerOf(n1) == pointerOf(n2) {
+			return true
+		}
+		return n1.EqualObject(n2)
+	case Array:
+		n2, ok := n2.(Array)
+		if !ok || len(n1) != len(n2) {
+			return false
+		}
+		return len(n1) == 0 || &n1[0] == &n2[0] || n1.EqualArray(n2)
+	default:
+		if Same(n1, n2) {
+			return true
+		}
 	}
 	if n, ok := n1.(Node); ok {
 		return n.Equal(n2)

--- a/uast/nodes/node.go
+++ b/uast/nodes/node.go
@@ -13,11 +13,6 @@ const applySort = false
 // Equal compares two subtrees.
 // Equality is checked by value (deep), not by reference.
 func Equal(n1, n2 External) bool {
-	if n1 == nil && n2 == nil {
-		return true
-	} else if n1 == nil || n2 == nil {
-		return false
-	}
 	if Same(n1, n2) {
 		return true
 	}
@@ -895,6 +890,34 @@ func Same(n1, n2 External) bool {
 	if !ok {
 		// second node is external, need to call SameAs on it
 		return n2.SameAs(n1)
+	}
+	// fast path
+	switch i1 := i1.(type) {
+	case Object:
+		i2, ok := i2.(Object)
+		if !ok || len(i1) != len(i2) {
+			return false
+		}
+		return pointerOf(i1) == pointerOf(i2)
+	case Array:
+		i2, ok := i2.(Array)
+		if !ok || len(i1) != len(i2) {
+			return false
+		}
+		if i1 == nil && i2 == nil {
+			return true
+		} else if i1 == nil || i2 == nil {
+			return false
+		} else if len(i1) == 0 {
+			return true
+		}
+		return &i1[0] == &i2[0]
+	case Value:
+		i2, ok := i2.(Value)
+		if !ok {
+			return false
+		}
+		return i1 == i2
 	}
 	// both nodes are internal - compare unique key
 	return UniqueKey(i1) == UniqueKey(i2)

--- a/uast/nodes/node.go
+++ b/uast/nodes/node.go
@@ -82,6 +82,61 @@ func Equal(n1, n2 External) bool {
 	return equalExt(n1, n2)
 }
 
+// NodeEqual compares two subtrees.
+// Equality is checked by value (deep), not by reference.
+func NodeEqual(n1, n2 Node) bool {
+	if n1 == nil && n2 == nil {
+		return true
+	} else if n1 == nil || n2 == nil {
+		return false
+	}
+	switch n1 := n1.(type) {
+	case String:
+		n2, ok := n2.(String)
+		return ok && n1 == n2
+	case Int:
+		n2, ok := n2.(Int)
+		if ok {
+			return n1 == n2
+		}
+	case Uint:
+		n2, ok := n2.(Uint)
+		if ok {
+			return n1 == n2
+		}
+	case Bool:
+		n2, ok := n2.(Bool)
+		return ok && n1 == n2
+	case Float:
+		n2, ok := n2.(Float)
+		if ok {
+			return n1 == n2
+		}
+	case Object:
+		n2, ok := n2.(Object)
+		if !ok {
+			return false
+		}
+		if len(n1) != len(n2) {
+			return false
+		}
+		if pointerOf(n1) == pointerOf(n2) {
+			return true
+		}
+		return n1.EqualObject(n2)
+	case Array:
+		n2, ok := n2.(Array)
+		if !ok {
+			return false
+		}
+		if len(n1) != len(n2) {
+			return false
+		}
+		return len(n1) == 0 || &n1[0] == &n2[0] || n1.EqualArray(n2)
+	}
+	return n1.Equal(n2)
+}
+
 // Node is a generic interface for a tree structure.
 //
 // Can be one of:

--- a/uast/nodes/node_test.go
+++ b/uast/nodes/node_test.go
@@ -391,6 +391,12 @@ func TestNodeEqual(t *testing.T) {
 			}
 			require.Equal(t, c.exp, Equal(n1, n2))
 			require.Equal(t, c.exp, Equal(n2, n1))
+			if no1, ok := n1.(Node); ok {
+				if no2, ok := n2.(Node); ok {
+					require.Equal(t, c.exp, NodeEqual(no1, no2))
+					require.Equal(t, c.exp, NodeEqual(no2, no1))
+				}
+			}
 			expHash := c.exp
 			if c.negHash {
 				expHash = !expHash

--- a/uast/nodes/node_test.go
+++ b/uast/nodes/node_test.go
@@ -522,3 +522,37 @@ func TestCount(t *testing.T) {
 	require.Equal(t, int(7), int(Count(root, KindsNotNil)))
 	require.Equal(t, int(4), int(Count(root, KindsValues)))
 }
+
+func BenchmarkNodeSame(b *testing.B) {
+	for _, c := range casesSame {
+		b.Run(c.name, func(b *testing.B) {
+			n1, n2 := c.n1, c.n2
+			if n2 == nil {
+				n2 = n1
+			}
+			for i := 0; i < b.N; i++ {
+				ok := Same(n1, n2)
+				if ok != c.exp {
+					b.Fatal("invalid result")
+				}
+			}
+		})
+	}
+}
+
+func BenchmarkNodeEqual(b *testing.B) {
+	for _, c := range casesEqual {
+		b.Run(c.name, func(b *testing.B) {
+			n1, n2 := c.n1, c.n2
+			if n2 == nil {
+				n2 = n1
+			}
+			for i := 0; i < b.N; i++ {
+				ok := Equal(n1, n2)
+				if ok != c.exp {
+					b.Fatal("invalid result")
+				}
+			}
+		})
+	}
+}

--- a/uast/transformer/ast.go
+++ b/uast/transformer/ast.go
@@ -72,7 +72,7 @@ func RolesFieldOp(vr string, op ArrayOp, roles ...role.Role) Field {
 func ASTObjectLeft(typ string, ast ObjectOp) ObjectOp {
 	if fields, ok := ast.Fields(); !ok {
 		panic("unexpected partial transform")
-	} else if _, ok := fields[uast.KeyRoles]; ok {
+	} else if fields.Has(uast.KeyRoles) {
 		panic("unexpected roles filed")
 	}
 	var obj Fields
@@ -95,7 +95,7 @@ type RolesByType func(typ string) role.Roles
 func ASTObjectRightCustom(typ string, norm ObjectOp, fnc RolesByType, rop ArrayOp, roles ...role.Role) ObjectOp {
 	if fields, ok := norm.Fields(); !ok {
 		panic("unexpected partial transform")
-	} else if _, ok := fields[uast.KeyRoles]; ok {
+	} else if fields.Has(uast.KeyRoles) {
 		panic("unexpected roles field")
 	}
 	var obj Fields

--- a/uast/transformer/ops.go
+++ b/uast/transformer/ops.go
@@ -235,13 +235,13 @@ func (Obj) Kinds() nodes.Kind {
 }
 
 func (o Obj) Fields() (FieldDescs, bool) {
-	fields := make(FieldDescs, len(o))
+	d := NewFieldDescs(len(o))
 	for k, v := range o {
 		f := FieldDesc{Optional: false}
 		f.SetValue(v)
-		fields[k] = f
+		d.Set(k, f)
 	}
-	return fields, true
+	return d, true
 }
 
 // fields converts this helper to a full Fields description.
@@ -293,33 +293,108 @@ func (f *FieldDesc) SetValue(sel Sel) {
 	}
 }
 
+func NewFieldDescs(n int) FieldDescs {
+	if n == 0 {
+		return FieldDescs{}
+	}
+	return FieldDescs{
+		fields: make([]fieldDesc, 0, n),
+		m:      make(map[string]int, n),
+	}
+}
+
+type fieldDesc struct {
+	name string
+	FieldDesc
+}
+
 // FieldDescs contains descriptions of static fields of an object.
 //
 // Transformations may return this type to indicate what fields they will require.
 //
 // See FieldDesc for details.
-type FieldDescs map[string]FieldDesc
+type FieldDescs struct {
+	fields []fieldDesc
+	m      map[string]int
+}
+
+// Len returns a number of fields.
+func (f *FieldDescs) Len() int {
+	if f == nil {
+		return 0
+	}
+	return len(f.fields)
+}
+
+// Index return the field descriptor and its name, given an index.
+func (f *FieldDescs) Index(i int) (FieldDesc, string) {
+	if f == nil || i < 0 || i >= len(f.fields) {
+		return FieldDesc{}, ""
+	}
+	d := f.fields[i]
+	return d.FieldDesc, d.name
+}
+
+// Has checks if a field with a given name exists.
+func (f *FieldDescs) Has(k string) bool {
+	if f == nil {
+		return false
+	}
+	_, ok := f.m[k]
+	return ok
+}
+
+// Get the field descriptor by its name.
+func (f *FieldDescs) Get(k string) (FieldDesc, bool) {
+	if f == nil {
+		return FieldDesc{}, false
+	}
+	i, ok := f.m[k]
+	if !ok {
+		return FieldDesc{}, false
+	}
+	return f.fields[i].FieldDesc, true
+}
+
+// Set a field descriptor by name.
+func (f *FieldDescs) Set(k string, d FieldDesc) {
+	if i, ok := f.m[k]; ok {
+		f.fields[i].FieldDesc = d
+		return
+	}
+	i := len(f.fields)
+	f.fields = append(f.fields, fieldDesc{name: k, FieldDesc: d})
+	if f.m == nil {
+		f.m = make(map[string]int)
+	}
+	f.m[k] = i
+}
 
 // Clone makes a copy of field description, without cloning each field values.
-func (f FieldDescs) Clone() FieldDescs {
-	if f == nil {
-		return nil
+func (f *FieldDescs) Clone() FieldDescs {
+	if f == nil || len(f.fields) == 0 {
+		return FieldDescs{}
 	}
-	fields := make(FieldDescs, len(f))
-	for k, v := range f {
-		fields[k] = v
+	f2 := NewFieldDescs(len(f.fields))
+	f2.fields = f2.fields[:len(f.fields)]
+	copy(f2.fields, f.fields)
+	for k, v := range f.m {
+		f2.m[k] = v
 	}
-	return fields
+	return f2
 }
 
 // CheckObj verifies that an object matches field descriptions.
 // It ignores all fields in the object that are not described.
-func (f FieldDescs) CheckObj(n nodes.Object) bool {
-	for k, d := range f {
+func (f *FieldDescs) CheckObj(n nodes.Object) bool {
+	if f == nil {
+		return true
+	}
+	for _, d := range f.fields {
 		if d.Optional {
 			continue
 		}
-		v, ok := n[k]
+		v, ok := n[d.name]
 		if !ok {
 			return false
 		}
@@ -425,7 +500,8 @@ func (op *opPartialObj) CheckObj(st *State, n nodes.Object) (bool, error) {
 	// TODO: consider throwing an error if a transform is defined as partial, but in fact it's not
 	other := n.CloneObject()
 	n = make(nodes.Object)
-	for k := range op.used {
+	for _, d := range op.used.fields {
+		k := d.name
 		if _, ok := other[k]; ok {
 			n[k] = other[k]
 			delete(other, k)
@@ -480,7 +556,7 @@ func JoinObj(ops ...ObjectOp) ObjectOp {
 		partial ObjectOp
 		out     []processedOp
 	)
-	required := make(FieldDescs)
+	required := NewFieldDescs(0)
 	for _, s := range ops {
 		if j, ok := s.(*opObjJoin); ok {
 			if j.partial != nil {
@@ -489,14 +565,15 @@ func JoinObj(ops ...ObjectOp) ObjectOp {
 				}
 				partial = j.partial
 			}
-			for k, req := range j.allFields {
-				if req2, ok := required[k]; ok {
+			for _, req := range j.allFields.fields {
+				k := req.name
+				if req2, ok := required.Get(k); ok {
 					// only allow this if values are fixed and equal
 					if req.Fixed == nil || req2.Fixed == nil || !nodes.Equal(*req.Fixed, *req2.Fixed) {
 						panic(ErrDuplicateField.New(k))
 					}
 				}
-				required[k] = req
+				required.Set(k, req.FieldDesc)
 			}
 			out = append(out, j.ops...)
 			continue
@@ -509,20 +586,21 @@ func JoinObj(ops ...ObjectOp) ObjectOp {
 			partial = s
 			continue
 		}
-		for k, req := range fields {
-			if _, ok := required[k]; ok {
+		for _, req := range fields.fields {
+			k := req.name
+			if required.Has(k) {
 				panic(ErrDuplicateField.New(k))
 			}
-			required[k] = req
+			required.Set(k, req.FieldDesc)
 		}
 		out = append(out, processedOp{op: s, fields: fields})
 	}
 	if partial != nil {
-		required = nil
+		required = NewFieldDescs(0)
 	}
 	for i := 0; i < len(out); i++ {
 		op := out[i]
-		if len(op.fields) != 0 {
+		if len(op.fields.fields) != 0 {
 			continue
 		}
 		if o, ok := op.op.(Obj); ok && len(o) == 0 && len(out) > 1 {
@@ -567,8 +645,9 @@ func (op *opObjJoin) CheckObj(st *State, n nodes.Object) (bool, error) {
 	src := n
 	n = n.CloneObject()
 	for _, s := range op.ops {
-		sub := make(nodes.Object, len(s.fields))
-		for k := range s.fields {
+		sub := make(nodes.Object, len(s.fields.fields))
+		for _, d := range s.fields.fields {
+			k := d.name
 			if v, ok := src[k]; ok {
 				sub[k] = v
 				delete(n, k)
@@ -613,7 +692,7 @@ func (op *opObjJoin) ConstructObj(st *State, n nodes.Object) (nodes.Object, erro
 		for k, v := range n2 {
 			if v2, ok := n[k]; ok && !nodes.Equal(v, v2) {
 				return nil, ErrDuplicateField.New(k)
-			} else if _, ok = s.fields[k]; !ok {
+			} else if !s.fields.Has(k) {
 				return nil, fmt.Errorf("undeclared field was set: %v", k)
 			}
 			n[k] = v
@@ -783,9 +862,9 @@ func (Fields) Kinds() nodes.Kind {
 }
 
 func (o Fields) Fields() (FieldDescs, bool) {
-	fields := make(FieldDescs, len(o))
+	fields := NewFieldDescs(len(o))
 	for _, f := range o {
-		fields[f.Name] = f.Desc()
+		fields.Set(f.Name, f.Desc())
 	}
 	return fields, true
 }
@@ -833,7 +912,7 @@ func (o Fields) CheckObj(st *State, n nodes.Object) (bool, error) {
 	if !allowUnusedFields {
 		set, _ := o.Fields() // TODO: optimize
 		for k := range n {
-			if _, ok := set[k]; !ok {
+			if !set.Has(k) {
 				return false, NewErrUnusedField(n, []string{k})
 			}
 		}
@@ -1282,7 +1361,7 @@ func CheckObj(s ObjectSel, op ObjectOp) ObjectOp {
 	// we always consider it as such
 	checks, _ := s.Fields()
 	// optional selectors doesn't make sense
-	for _, f := range checks {
+	for _, f := range checks.fields {
 		if f.Optional {
 			panic("optional fields are not allowed in CheckObj")
 		}
@@ -1290,8 +1369,8 @@ func CheckObj(s ObjectSel, op ObjectOp) ObjectOp {
 
 	// merge maps, prefer fields from op
 	fields, full := op.Fields()
-	for name, f := range fields {
-		checks[name] = f
+	for _, f := range fields.fields {
+		checks.Set(f.name, f.FieldDesc)
 	}
 
 	return &opCheckObj{sel: s, op: op, fields: checks, full: full}
@@ -1374,7 +1453,7 @@ func (*opObjNot) Kinds() nodes.Kind {
 
 func (op *opObjNot) Fields() (FieldDescs, bool) {
 	// TODO(dennwc): FieldDescs should contain negative checks as well
-	return nil, false // not sure; can be anything
+	return FieldDescs{}, false // not sure; can be anything
 }
 
 func (op *opObjNot) CheckObj(st *State, n nodes.Object) (bool, error) {
@@ -1446,11 +1525,11 @@ func (Has) Kinds() nodes.Kind {
 }
 
 func (m Has) Fields() (FieldDescs, bool) {
-	desc := make(FieldDescs, len(m))
+	desc := NewFieldDescs(len(m))
 	for k, sel := range m {
 		f := FieldDesc{Optional: false}
 		f.SetValue(sel)
-		desc[k] = f
+		desc.Set(k, f)
 	}
 	return desc, false
 }
@@ -1488,10 +1567,10 @@ func (HasFields) Kinds() nodes.Kind {
 }
 
 func (m HasFields) Fields() (FieldDescs, bool) {
-	desc := make(FieldDescs, len(m))
+	desc := NewFieldDescs(len(m))
 	for k, expect := range m {
 		if expect {
-			desc[k] = FieldDesc{Optional: false}
+			desc.Set(k, FieldDesc{Optional: false})
 		}
 	}
 	return desc, false
@@ -1585,26 +1664,26 @@ func CasesObj(vr string, common ObjectOp, cases ObjectOps) ObjectOp {
 		if !ok {
 			panic("partial transforms are not allowed in Cases")
 		}
-		for _, f := range arr {
+		for _, f := range arr.fields {
 			if f.Optional {
 				panic("optional fields are not allowed in Cases")
 			}
 		}
 		if i == 0 {
 			// use as a baseline wipe all specific constraints (might differ in cases)
-			fields = make(FieldDescs, len(arr))
-			for k := range arr {
-				fields[k] = FieldDesc{Optional: false}
+			fields = NewFieldDescs(len(arr.fields))
+			for _, f := range arr.fields {
+				fields.Set(f.name, FieldDesc{Optional: false})
 			}
 			continue
 		}
 		// check that all other cases mention the case set of fields
-		if len(arr) != len(fields) {
+		if len(arr.fields) != len(fields.fields) {
 			panic("all cases should have the same number of fields")
 		}
-		for k := range arr {
-			if _, ok := fields[k]; !ok {
-				panic(fmt.Errorf("field %s does not exists in case %d", k, i))
+		for _, f := range arr.fields {
+			if !fields.Has(f.name) {
+				panic(fmt.Errorf("field %s does not exists in case %d", f.name, i))
 			}
 		}
 	}

--- a/uast/transformer/ops.go
+++ b/uast/transformer/ops.go
@@ -69,7 +69,7 @@ func (op opIs) Kinds() nodes.Kind {
 }
 
 func (op opIs) Check(st *State, n nodes.Node) (bool, error) {
-	return nodes.Equal(op.n, n), nil
+	return nodes.NodeEqual(op.n, n), nil
 }
 
 func (op opIs) Construct(st *State, n nodes.Node) (nodes.Node, error) {
@@ -398,7 +398,7 @@ func (f *FieldDescs) CheckObj(n nodes.Object) bool {
 		if !ok {
 			return false
 		}
-		if d.Fixed != nil && !nodes.Equal(*d.Fixed, v) {
+		if d.Fixed != nil && !nodes.NodeEqual(*d.Fixed, v) {
 			return false
 		}
 	}
@@ -569,7 +569,7 @@ func JoinObj(ops ...ObjectOp) ObjectOp {
 				k := req.name
 				if req2, ok := required.Get(k); ok {
 					// only allow this if values are fixed and equal
-					if req.Fixed == nil || req2.Fixed == nil || !nodes.Equal(*req.Fixed, *req2.Fixed) {
+					if req.Fixed == nil || req2.Fixed == nil || !nodes.NodeEqual(*req.Fixed, *req2.Fixed) {
 						panic(ErrDuplicateField.New(k))
 					}
 				}
@@ -678,7 +678,7 @@ func (op *opObjJoin) ConstructObj(st *State, n nodes.Object) (nodes.Object, erro
 			return nil, err
 		}
 		for k, v := range np {
-			if v2, ok := n[k]; ok && !nodes.Equal(v, v2) {
+			if v2, ok := n[k]; ok && !nodes.NodeEqual(v, v2) {
 				return nil, ErrDuplicateField.New(k)
 			}
 			n[k] = v
@@ -690,7 +690,7 @@ func (op *opObjJoin) ConstructObj(st *State, n nodes.Object) (nodes.Object, erro
 			return nil, err
 		}
 		for k, v := range n2 {
-			if v2, ok := n[k]; ok && !nodes.Equal(v, v2) {
+			if v2, ok := n[k]; ok && !nodes.NodeEqual(v, v2) {
 				return nil, ErrDuplicateField.New(k)
 			} else if !s.fields.Has(k) {
 				return nil, fmt.Errorf("undeclared field was set: %v", k)

--- a/uast/transformer/semantic.go
+++ b/uast/transformer/semantic.go
@@ -30,10 +30,11 @@ func uastType(uobj interface{}, op ObjectOp, part string) ObjectOp {
 	if len(zero) == 0 {
 		return JoinObj(obj, op)
 	}
-	for k := range fields {
-		if k == uast.KeyType {
+	for _, f := range fields.fields {
+		if f.name == uast.KeyType {
 			continue
 		}
+		k := f.name
 		_, ok := zero[k]
 		_, ok2 := opt[k]
 		if !ok && !ok2 {

--- a/uast/transformer/transformer.go
+++ b/uast/transformer/transformer.go
@@ -267,7 +267,7 @@ func (m *mappings) index() {
 		case ObjectOp:
 			specific := false
 			fields, _ := op.Fields()
-			if f, ok := fields[uast.KeyType]; ok && !f.Optional {
+			if f, ok := fields.Get(uast.KeyType); ok && !f.Optional {
 				if f.Fixed != nil {
 					typ := *f.Fixed
 					if typ, ok := typ.(nodes.String); ok {


### PR DESCRIPTION
This PR incorporates two optimizations found during recent profiling session.

First optimization changes `nodes.Equal` function to be more efficient. The function itself is pretty fast, but it executes so often that it dominates the execution time of the DSL (node filtering). The change inlines type-specific checks and defines a specialized `NodeEqual` function that omits interface convertions (`runtime.convI2I`).

The second optimization changes the `transform.FieldDescs` (field descriptors) from map to a struct with a slice. This increases the performance of range loops over this structure, resulting in ~30% DSL performance increase. The structure makes a difference, because `FieldDescs` is used during node matching for partial transformations that are used more often in recent driver. DSL cannot optimize the filtering for this specific transform, so it end up testing all nodes, thus map iteration give a considerable performance penalty for this case.

Benchmark comparison for C# driver with this change applied:
```
benchmark                                            old ns/op      new ns/op      delta
BenchmarkCsharpDriver/transform/binary_search-4      153618333      76028455       -50.51%
BenchmarkCsharpDriver/transform/parser_context-4     2385605943     1153439690     -51.65%
```