### PR TITLE
Allow to run driver UAST transform benchmark on the host

### DIFF
--- a/driver/fixtures/fixtures.go
+++ b/driver/fixtures/fixtures.go
@@ -44,6 +44,11 @@ type DockerConfig struct {
 	Image string
 }
 
+func runsInDocker() bool {
+	_, err := os.Stat("/.dockerenv")
+	return err == nil
+}
+
 type Suite struct {
 	Lang string
 	Ext  string // with dot
@@ -152,6 +157,9 @@ func isTest(name, ext string) (string, bool) {
 }
 
 func (s *Suite) testFixturesNative(t *testing.T) {
+	if !runsInDocker() {
+		t.SkipNow()
+	}
 	list, err := ioutil.ReadDir(s.Path)
 	require.NoError(t, err)
 
@@ -223,6 +231,9 @@ func (s *Suite) testFixturesNative(t *testing.T) {
 }
 
 func (s *Suite) testFixturesUAST(t *testing.T, mode driver.Mode, suf string, blacklist ...string) {
+	if !runsInDocker() {
+		t.SkipNow()
+	}
 	ctx := context.Background()
 
 	list, err := ioutil.ReadDir(s.Path)
@@ -411,6 +422,9 @@ func isBench(name, ext string) (string, bool) {
 }
 
 func (s *Suite) benchmarkFixtures(b *testing.B) {
+	if !runsInDocker() {
+		b.SkipNow()
+	}
 	b.StopTimer()
 	ctx := context.Background()
 


### PR DESCRIPTION
Currently, all benchmarks including the ones for transformation pipeline run the driver instance to parse files. This prevents running those benchmarks on the host since driver runtime is necessary to parse files.

Instead, rewrite transformation pipeline benchmarks to use AST files generated by tests (fixture files). Those files will always be there since we use them to test the output of the driver.

This allows running this specific benchmark on the host, making results more stable.

A side effect is that, due to the way how `uast.RolesOf` is implemented, it will always append `Unannotated` role to all nodes that do not define roles and are not part of the Semantic UAST schema.

YAML encoder that is used to write fixtures in tests uses this function to dump native AST. As a result, all AST nodes end up with an `Unannotated` role and a new `@role` field. This breaks the transformation tests because of the unknown field that should not exist for Native parsing mode.

This PR also adds an option for the YAML UAST encoder to disable roles for native AST. Test are changed according, so drivers will need to re-generate native fixtures after the next SDK update.