### PR TITLE
Fix edge case for comment parsing

### DIFF
--- a/uast/transformer/semantic.go
+++ b/uast/transformer/semantic.go
@@ -181,6 +181,9 @@ func (c *commentElems) Split(text string) bool {
 	if i >= 0 {
 		c.Prefix = text[:i]
 		text = text[i:]
+	} else {
+		c.Prefix = text
+		text = ""
 	}
 
 	// find suffix

--- a/uast/transformer/semantic_test.go
+++ b/uast/transformer/semantic_test.go
@@ -22,6 +22,15 @@ func TestComment(t *testing.T) {
 			},
 		},
 		{
+			name: "space",
+			text: "// ",
+			exp: commentElems{
+				StartToken: "//", EndToken: "",
+				Prefix: " ",
+				Text:   "",
+			},
+		},
+		{
 			name: "new line",
 			text: "// some text\n",
 			exp: commentElems{


### PR DESCRIPTION
Comment parser does a correct check for the case when only stylistic characters are present, but it does not set the prefix correctly for this case.

Signed-off-by: Denys Smirnov <denys@sourced.tech>