### PR TITLE
Restart native driver in case it crashes

### DIFF
--- a/driver/native/internal/crash/main.go
+++ b/driver/native/internal/crash/main.go
@@ -1,0 +1,27 @@
+package main
+
+import (
+	"context"
+
+	"gopkg.in/bblfsh/sdk.v2/driver/native"
+	"gopkg.in/bblfsh/sdk.v2/uast/nodes"
+)
+
+type mockDriver struct{}
+
+func (mockDriver) Start() error {
+	panic("died")
+	return nil
+}
+
+func (mockDriver) Parse(ctx context.Context, src string) (nodes.Node, error) {
+	panic("unreachable")
+}
+
+func (mockDriver) Close() error {
+	return nil
+}
+
+func main() {
+	native.Main(mockDriver{})
+}

--- a/driver/native/internal/crash/manifest.toml
+++ b/driver/native/internal/crash/manifest.toml
@@ -1,0 +1,8 @@
+language = "fixture"
+status = "beta"
+version = "42"
+build = 2015-10-21T04:29:00Z
+commit = "424242+"
+
+[runtime]
+  os = "alpine"

--- a/driver/native/internal/crash/mock
+++ b/driver/native/internal/crash/mock
@@ -1,0 +1,4 @@
+#!/bin/bash
+dir=$(dirname $0)
+cd $dir
+exec go run ./main.go $@

--- a/driver/native/internal/simple/main.go
+++ b/driver/native/internal/simple/main.go
@@ -14,6 +14,9 @@ func (mockDriver) Start() error {
 }
 
 func (mockDriver) Parse(ctx context.Context, src string) (nodes.Node, error) {
+	if src == "die" {
+		panic("died")
+	}
 	return nodes.Object{
 		"root": nodes.Object{
 			"key": nodes.String(src),

--- a/driver/native/native.go
+++ b/driver/native/native.go
@@ -289,6 +289,9 @@ func (d *Driver) Parse(rctx context.Context, src string) (nodes.Node, error) {
 		// driver just died; we don't care about exit code
 		<-d.cmdErr
 		// try to restart it once
+		// TODO(dennwc): use exponential backoff? but it may slow down the processing in case
+		//				 a user sends a batch of broken files
+		//				 maybe we can somehow differentiate between those two cases?
 		if err := d.Start(); err != nil {
 			return nil, driver.ErrDriverFailure.Wrap(err, "driver restart failed")
 		}

--- a/driver/native/native_test.go
+++ b/driver/native/native_test.go
@@ -55,6 +55,31 @@ func TestEncoding(t *testing.T) {
 	}
 }
 
+func TestNativeDriverNativeCrash(t *testing.T) {
+	require := require.New(t)
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second*5)
+	defer cancel()
+
+	d := NewDriverAt("internal/crash/mock", "")
+
+	// cannot detect crash here because of native protocol limitations
+	err := d.Start()
+	require.NoError(err)
+
+	// all requests should fail the same way
+	_, err = d.Parse(ctx, "foo")
+	require.True(ErrDriverCrashed.Is(err))
+	require.True(derrors.ErrDriverFailure.Is(err))
+
+	_, err = d.Parse(ctx, "bar")
+	require.True(ErrDriverCrashed.Is(err))
+	require.True(derrors.ErrDriverFailure.Is(err))
+
+	err = d.Close()
+	require.NoError(err)
+}
+
 func TestNativeDriverNativeParse(t *testing.T) {
 	require := require.New(t)
 
@@ -70,7 +95,7 @@ func TestNativeDriverNativeParse(t *testing.T) {
 	require.NoError(err)
 }
 
-func TestNativeDriverNativeCrash(t *testing.T) {
+func TestNativeDriverNativeParseCrash(t *testing.T) {
 	require := require.New(t)
 
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second*5)
@@ -80,7 +105,7 @@ func TestNativeDriverNativeCrash(t *testing.T) {
 	err := d.Start()
 	require.NoError(err)
 
-	// fist request should succeed
+	// first request should succeed
 	r, err := d.Parse(ctx, "foo")
 	require.NoError(err)
 	require.Equal(mockResponse("foo"), r)


### PR DESCRIPTION
It turned out we don't have any logic to recover from a native driver crash (cool, right?).

`bblfshd` is of no help here since the Go driver server (the process that `bblfshd` starts in the container) usually survives the crash. `bblfshd` still thinks that the request failure was temporary and sends new requests, while driver server is not smart enough to restart the native driver process.

This change allows Go driver server to restart the native driver after a crash. As a bonus, it fixes an FD leak on driver close.

Logic is the following: if the driver server sees the end of `stdout` when waiting for a response, it assumes that the driver crashed, restarts it and returns an error to the client. The request of a next client (with a different file) may succeed this way.

Addresses #380 (need to check)

Signed-off-by: Denys Smirnov <denys@sourced.tech>