### PR TITLE
Restart the driver in case the protocol is broken

### DIFF
--- a/driver/native/internal/simple/main.go
+++ b/driver/native/internal/simple/main.go
@@ -2,6 +2,8 @@ package main
 
 import (
 	"context"
+	"fmt"
+	"os"
 
 	"gopkg.in/bblfsh/sdk.v2/driver/native"
 	"gopkg.in/bblfsh/sdk.v2/uast/nodes"
@@ -14,8 +16,14 @@ func (mockDriver) Start() error {
 }
 
 func (mockDriver) Parse(ctx context.Context, src string) (nodes.Node, error) {
-	if src == "die" {
+	switch src {
+	case "die":
+		// just die, prints stack trace on stderr
 		panic("died")
+	case "print-and-die":
+		// protocol runs on stdout, break it and then exit
+		fmt.Println("crash command received")
+		os.Exit(0)
 	}
 	return nodes.Object{
 		"root": nodes.Object{


### PR DESCRIPTION
The fix included in #381 was not enough to fix #380. The case is a bit different: the driver first breaks the native protocol flow by printing on stdout, and then it crashes.

This PR makes sure to restart the driver in both cases and includes a new test case.

Fixes #380

Signed-off-by: Denys Smirnov <denys@sourced.tech>