### PR TITLE
Support UTF8 and UTF16 line-column index lookups

### DIFF
--- a/uast/transformer/positioner/positions.go
+++ b/uast/transformer/positioner/positions.go
@@ -182,30 +182,27 @@ func newPositionIndexUnicode(data []byte) *positionIndex {
 		if r == '\n' {
 			idx.addLineOffset(i + 1)
 		}
-		if n == cur.runeSize8 {
-			// continue this span
-			cur.numRunes++
-			runes++
-			codePoints += cur.runeSize16
-			i += n - 1
-			continue
+
+		if n != cur.runeSize8 {
+			if cur.numRunes != 0 {
+				// save previous span
+				idx.spans = append(idx.spans, cur)
+			}
+			// start a new span
+			cur = runeSpan{
+				byteOff:       i,
+				firstRuneInd:  runes,
+				firstUTF16Ind: codePoints,
+				runeSize8:     n,
+				runeSize16:    1,
+			}
+			if r1, r2 := utf16.EncodeRune(r); r1 != utf8.RuneError || r2 != utf8.RuneError {
+				// surrogate pair: needs two UTF-16 code points
+				cur.runeSize16 = 2
+			}
 		}
-		if cur.numRunes != 0 {
-			idx.spans = append(idx.spans, cur)
-		}
-		// make a new span
-		cur = runeSpan{
-			byteOff:       i,
-			firstRuneInd:  runes,
-			firstUTF16Ind: codePoints,
-			numRunes:      1,
-			runeSize8:     n,
-			runeSize16:    1,
-		}
-		if r1, r2 := utf16.EncodeRune(r); r1 != utf8.RuneError || r2 != utf8.RuneError {
-			// surrogate pair: needs two UTF-16 code points
-			cur.runeSize16 = 2
-		}
+
+		cur.numRunes++
 		runes++
 		codePoints += cur.runeSize16
 		i += n - 1

--- a/uast/transformer/positioner/positions.go
+++ b/uast/transformer/positioner/positions.go
@@ -99,7 +99,7 @@ func (t Positioner) OnCode(code string) transformer.Transformer {
 }
 
 func fromLineCol(idx *positionIndex, pos *uast.Position) error {
-	offset, err := idx.Offset(int(pos.Line), int(pos.Col))
+	offset, err := idx.FromLineCol(int(pos.Line), int(pos.Col))
 	if err != nil {
 		return err
 	}
@@ -118,7 +118,7 @@ func fromOffset(idx *positionIndex, pos *uast.Position) error {
 }
 
 func fromUnicodeOffset(idx *positionIndex, pos *uast.Position) error {
-	off, err := idx.RuneOffset(int(pos.Offset))
+	off, err := idx.FromRuneOffset(int(pos.Offset))
 	if err != nil {
 		return err
 	}
@@ -127,7 +127,7 @@ func fromUnicodeOffset(idx *positionIndex, pos *uast.Position) error {
 }
 
 func fromUTF16Offset(idx *positionIndex, pos *uast.Position) error {
-	off, err := idx.UTF16Offset(int(pos.Offset))
+	off, err := idx.FromUTF16Offset(int(pos.Offset))
 	if err != nil {
 		return err
 	}
@@ -136,7 +136,7 @@ func fromUTF16Offset(idx *positionIndex, pos *uast.Position) error {
 }
 
 func fromUnicodeLineCol(idx *positionIndex, pos *uast.Position) error {
-	off, err := idx.LineColUnicode(int(pos.Line), int(pos.Col))
+	off, err := idx.FromUnicodeLineCol(int(pos.Line), int(pos.Col))
 	if err != nil {
 		return err
 	}
@@ -145,7 +145,7 @@ func fromUnicodeLineCol(idx *positionIndex, pos *uast.Position) error {
 }
 
 func fromUTF16LineCol(idx *positionIndex, pos *uast.Position) error {
-	off, err := idx.LineColUTF16(int(pos.Line), int(pos.Col))
+	off, err := idx.FromUTF16LineCol(int(pos.Line), int(pos.Col))
 	if err != nil {
 		return err
 	}
@@ -308,9 +308,9 @@ func (idx *positionIndex) checkLine(line int) error {
 	return nil
 }
 
-// Offset returns a zero-based byte offset given a one-based line and column.
+// FromLineCol returns a zero-based byte offset given a one-based line and column.
 // It returns an error if the given line and column are out of bounds.
-func (idx *positionIndex) Offset(line, col int) (int, error) {
+func (idx *positionIndex) FromLineCol(line, col int) (int, error) {
 	if err := idx.checkLine(line); err != nil {
 		return -1, err
 	}
@@ -330,8 +330,8 @@ func (idx *positionIndex) Offset(line, col int) (int, error) {
 	return lineOffset + col - 1, nil
 }
 
-// RuneOffset returns a zero-based byte offset given a zero-based Unicode character offset.
-func (idx *positionIndex) RuneOffset(offset int) (int, error) {
+// FromRuneOffset returns a zero-based byte offset given a zero-based Unicode character offset.
+func (idx *positionIndex) FromRuneOffset(offset int) (int, error) {
 	var last int
 	if len(idx.spans) != 0 {
 		s := idx.spans[len(idx.spans)-1]
@@ -351,8 +351,8 @@ func (idx *positionIndex) RuneOffset(offset int) (int, error) {
 	return int(s.byteOff) + int(s.runeSize8)*(offset-int(s.firstRuneInd)), nil
 }
 
-// UTF16Offset returns a zero-based byte offset given a zero-based UTF-16 code point offset.
-func (idx *positionIndex) UTF16Offset(offset int) (int, error) {
+// FromUTF16Offset returns a zero-based byte offset given a zero-based UTF-16 code point offset.
+func (idx *positionIndex) FromUTF16Offset(offset int) (int, error) {
 	var last int
 	if len(idx.spans) != 0 {
 		s := idx.spans[len(idx.spans)-1]
@@ -381,9 +381,9 @@ func (idx *positionIndex) spanForOffset(off int) int {
 	return i - 1
 }
 
-// LineColUnicode returns a zero-based byte offset given a one-based line and Unicode column.
+// FromUnicodeLineCol returns a zero-based byte offset given a one-based line and Unicode column.
 // It returns an error if the given line and column are out of bounds.
-func (idx *positionIndex) LineColUnicode(line, col int) (int, error) {
+func (idx *positionIndex) FromUnicodeLineCol(line, col int) (int, error) {
 	if err := idx.checkLine(line); err != nil {
 		return -1, err
 	}
@@ -417,9 +417,9 @@ func (idx *positionIndex) LineColUnicode(line, col int) (int, error) {
 	return int(s.byteOff) + (col-int(s.runeCol))*int(s.runeSize8), nil
 }
 
-// LineColUTF16 returns a zero-based byte offset given a one-based line and UTF16 code point column.
+// FromUTF16LineCol returns a zero-based byte offset given a one-based line and UTF16 code point column.
 // It returns an error if the given line and column are out of bounds.
-func (idx *positionIndex) LineColUTF16(line, col int) (int, error) {
+func (idx *positionIndex) FromUTF16LineCol(line, col int) (int, error) {
 	if err := idx.checkLine(line); err != nil {
 		return -1, err
 	}

--- a/uast/transformer/positioner/positions_test.go
+++ b/uast/transformer/positioner/positions_test.go
@@ -155,7 +155,7 @@ a3`
 			require.Equal(t, c.Line, uint32(line))
 			require.Equal(t, c.Col, uint32(col))
 
-			off, err := ind.Offset(int(c.Line), int(c.Col))
+			off, err := ind.FromLineCol(int(c.Line), int(c.Col))
 			require.NoError(t, err)
 			require.Equal(t, c.Offset, uint32(off))
 		})
@@ -201,7 +201,7 @@ a4`
 	ind := newPositionIndexUnicode([]byte(source))
 	for _, c := range cases {
 		t.Run("", func(t *testing.T) {
-			off, err := ind.RuneOffset(c.runeOff)
+			off, err := ind.FromRuneOffset(c.runeOff)
 			require.NoError(t, err)
 			require.Equal(t, c.byteOff, off)
 
@@ -254,7 +254,7 @@ a4`
 	ind := newPositionIndexUnicode([]byte(source))
 	for _, c := range cases {
 		t.Run("", func(t *testing.T) {
-			off, err := ind.UTF16Offset(c.cpOff)
+			off, err := ind.FromUTF16Offset(c.cpOff)
 			require.NoError(t, err)
 			require.Equal(t, c.byteOff, off)
 
@@ -313,11 +313,11 @@ a4`
 	ind := newPositionIndexUnicode([]byte(source))
 	for _, c := range cases {
 		t.Run("", func(t *testing.T) {
-			off, err := ind.LineColUnicode(c.line, c.col8)
+			off, err := ind.FromUnicodeLineCol(c.line, c.col8)
 			require.NoError(t, err)
 			require.Equal(t, c.byteOff, off)
 
-			off, err = ind.LineColUTF16(c.line, c.col16)
+			off, err = ind.FromUTF16LineCol(c.line, c.col16)
 			require.NoError(t, err)
 			require.Equal(t, c.byteOff, off)
 		})

--- a/uast/transformer/positioner/positions_test.go
+++ b/uast/transformer/positioner/positions_test.go
@@ -110,15 +110,19 @@ func TestFillOffsetEmptyFile(t *testing.T) {
 func TestPosIndexSpans(t *testing.T) {
 	const source = `line1
 𝓏𝓏2
-ё3
+aё3
+
 a4`
 	ind := newPositionIndexUnicode([]byte(source))
 	require.Equal(t, []runeSpan{
 		{firstRuneInd: 0, firstUTF16Ind: 0, byteOff: 0, runeSize8: 1, runeSize16: 1, numRunes: 6},
 		{firstRuneInd: 6, firstUTF16Ind: 6, byteOff: 6, runeSize8: 4, runeSize16: 2, numRunes: 2},
 		{firstRuneInd: 8, firstUTF16Ind: 10, byteOff: 14, runeSize8: 1, runeSize16: 1, numRunes: 2},
-		{firstRuneInd: 10, firstUTF16Ind: 12, byteOff: 16, runeSize8: 2, runeSize16: 1, numRunes: 1},
-		{firstRuneInd: 11, firstUTF16Ind: 13, byteOff: 18, runeSize8: 1, runeSize16: 1, numRunes: 4},
+		{firstRuneInd: 10, firstUTF16Ind: 12, byteOff: 16, runeSize8: 1, runeSize16: 1, numRunes: 1},
+		{firstRuneInd: 11, firstUTF16Ind: 13, byteOff: 17, runeSize8: 2, runeSize16: 1, numRunes: 1},
+		{firstRuneInd: 12, firstUTF16Ind: 14, byteOff: 19, runeSize8: 1, runeSize16: 1, numRunes: 2},
+		{firstRuneInd: 14, firstUTF16Ind: 16, byteOff: 21, runeSize8: 1, runeSize16: 1, numRunes: 1},
+		{firstRuneInd: 15, firstUTF16Ind: 17, byteOff: 22, runeSize8: 1, runeSize16: 1, numRunes: 2},
 	}, ind.spans)
 }
 

--- a/uast/transformer/positioner/positions_test.go
+++ b/uast/transformer/positioner/positions_test.go
@@ -107,6 +107,21 @@ func TestFillOffsetEmptyFile(t *testing.T) {
 	require.Equal(expected, out)
 }
 
+func TestPosIndexSpans(t *testing.T) {
+	const source = `line1
+𝓏𝓏2
+ё3
+a4`
+	ind := newPositionIndexUnicode([]byte(source))
+	require.Equal(t, []runeSpan{
+		{firstRuneInd: 0, firstUTF16Ind: 0, byteOff: 0, runeSize8: 1, runeSize16: 1, numRunes: 6},
+		{firstRuneInd: 6, firstUTF16Ind: 6, byteOff: 6, runeSize8: 4, runeSize16: 2, numRunes: 2},
+		{firstRuneInd: 8, firstUTF16Ind: 10, byteOff: 14, runeSize8: 1, runeSize16: 1, numRunes: 2},
+		{firstRuneInd: 10, firstUTF16Ind: 12, byteOff: 16, runeSize8: 2, runeSize16: 1, numRunes: 1},
+		{firstRuneInd: 11, firstUTF16Ind: 13, byteOff: 18, runeSize8: 1, runeSize16: 1, numRunes: 4},
+	}, ind.spans)
+}
+
 func TestPosIndex(t *testing.T) {
 	// Verify that a multi-byte Unicode rune does not displace offsets after
 	// its occurrence in the input. Test few other simple cases as well.


### PR DESCRIPTION
Some drivers only provide line-column information that with the column in either UTF8 runes or UTF16 code points.

This change adds necessary information to the index to calculate the byte offset from those line-column pairs.

As a consequence, spans are now added for each new line in addition to each sequence of equally-sized runes. This increases the memory required for the index from `O(1)` to `O(N)` (where `N` is the line count).