### PR TITLE
Language aliases and languages protocol v2

### DIFF
--- a/build/build.go
+++ b/build/build.go
@@ -257,9 +257,7 @@ func (d *Driver) FillManifest(dest string) error {
 		return err
 	}
 	m.Version = vers
-
-	now := time.Now().UTC()
-	m.Build = &now
+	m.Build = time.Now().UTC()
 
 	bm, err := d.readBuildManifest()
 	if err != nil {

--- a/build/build_test.go
+++ b/build/build_test.go
@@ -13,6 +13,7 @@ import (
 	"google.golang.org/grpc"
 
 	"github.com/bblfsh/sdk/v3/driver"
+	"github.com/bblfsh/sdk/v3/driver/manifest"
 	"github.com/bblfsh/sdk/v3/internal/docker"
 	"github.com/bblfsh/sdk/v3/protocol"
 	"github.com/bblfsh/sdk/v3/uast/nodes"
@@ -154,4 +155,12 @@ func (d *dockerDriver) Close() error {
 
 func (d *dockerDriver) Parse(ctx context.Context, src string, opts *driver.ParseOptions) (nodes.Node, error) {
 	return d.d.Parse(ctx, src, opts)
+}
+
+func (d *dockerDriver) Version(ctx context.Context) (driver.Version, error) {
+	return d.d.Version(ctx)
+}
+
+func (d *dockerDriver) Languages(ctx context.Context) ([]manifest.Manifest, error) {
+	return d.d.Languages(ctx)
 }

--- a/driver/driver.go
+++ b/driver/driver.go
@@ -4,6 +4,7 @@ package driver
 import (
 	"context"
 	"fmt"
+	"time"
 
 	"gopkg.in/src-d/go-errors.v1"
 
@@ -25,6 +26,11 @@ var (
 
 	// ErrModeNotSupported is returned if a UAST transformation mode is not supported by the driver.
 	ErrModeNotSupported = errors.NewKind("transform mode not supported")
+)
+
+const (
+	// ManifestLocation is the path of the manifest file in the driver image.
+	ManifestLocation = "/opt/driver/etc/" + manifest.Filename
 )
 
 // ErrMulti joins multiple errors.
@@ -87,13 +93,24 @@ type Driver interface {
 	// Native driver failures are indicated by ErrDriverFailure and UAST transformation are indicated by ErrTransformFailure.
 	// All other errors indicate a protocol or server failure.
 	Parse(ctx context.Context, src string, opts *ParseOptions) (nodes.Node, error)
+
+	// Version returns a version of the driver or the server, depending where is this interface is implemented.
+	Version(ctx context.Context) (Version, error)
+
+	// Languages returns a list of manifests for languages supported by this driver or the server.
+	Languages(ctx context.Context) ([]manifest.Manifest, error)
+}
+
+// Version information for driver or the server.
+type Version struct {
+	Version string    // the version label for the driver, e.g., 'v1.2.3-tag' or 'undefined'
+	Build   time.Time // the timestamp when the driver was built
 }
 
 // DriverModule is an interface for a driver instance.
 type DriverModule interface {
 	Module
 	Driver
-	Manifest() (manifest.Manifest, error)
 }
 
 // Native is a base interface of a language driver that returns a native AST.

--- a/driver/impl.go
+++ b/driver/impl.go
@@ -73,7 +73,15 @@ func (d *driverImpl) Parse(rctx context.Context, src string, opts *ParseOptions)
 	return ast, err
 }
 
-// Manifest returns a driver manifest.
-func (d *driverImpl) Manifest() (manifest.Manifest, error) {
-	return *d.m, nil // TODO: clone
+// Version returns driver version.
+func (d *driverImpl) Version(ctx context.Context) (Version, error) {
+	return Version{
+		Version: d.m.Version,
+		Build:   d.m.Build,
+	}, nil
+}
+
+// Languages returns a single driver manifest for the language supported by the driver.
+func (d *driverImpl) Languages(ctx context.Context) ([]manifest.Manifest, error) {
+	return []manifest.Manifest{*d.m}, nil // TODO: clone
 }

--- a/driver/manifest/manifest.go
+++ b/driver/manifest/manifest.go
@@ -95,8 +95,9 @@ type Documentation struct {
 type Manifest struct {
 	Name          string            `toml:"name"` // human-readable name
 	Language      string            `toml:"language"`
+	Aliases       []string          `toml:"aliases"` // language name aliases, see Enry/Linguist
 	Version       string            `toml:"version,omitempty" json:",omitempty"`
-	Build         *time.Time        `toml:"build,omitempty" json:",omitempty"`
+	Build         time.Time         `toml:"build,omitempty" json:",omitempty"`
 	Status        DevelopmentStatus `toml:"status"`
 	SDKVersion    string            `toml:"-"` // read from go.mod
 	Documentation *Documentation    `toml:"documentation,omitempty" json:",omitempty"`

--- a/driver/manifest/manifest_test.go
+++ b/driver/manifest/manifest_test.go
@@ -12,6 +12,7 @@ import (
 var fixture = `
 name = "Foo"
 language = "foo"
+build = 0001-01-01T00:00:00Z
 status = ""
 features = ["ast", "uast", "roles"]
 

--- a/driver/server/common.go
+++ b/driver/server/common.go
@@ -11,7 +11,7 @@ var DefaultDriver driver.Native = native.NewDriver("")
 var (
 	// ManifestLocation location of the manifest file. Should not override
 	// this variable unless you know what are you doing.
-	ManifestLocation = "/opt/driver/etc/" + manifest.Filename
+	ManifestLocation = driver.ManifestLocation
 )
 
 // Run is a common main function used as an entry point for drivers.

--- a/driver/server/server.go
+++ b/driver/server/server.go
@@ -1,7 +1,9 @@
 package server
 
 import (
+	"context"
 	"flag"
+	"fmt"
 	"io"
 	"net"
 	"os"
@@ -81,10 +83,13 @@ func (s *Server) initialize() error {
 	if err := s.initializeLogger(); err != nil {
 		return err
 	}
-	m, err := s.d.Manifest()
+	list, err := s.d.Languages(context.Background())
 	if err != nil {
 		return err
+	} else if len(list) != 1 {
+		return fmt.Errorf("expected exactly one manifest, got %d", len(list))
 	}
+	m := list[0]
 	if err := s.initializeTracing(m.Language + "-driver"); err != nil {
 		return err
 	}
@@ -96,7 +101,7 @@ func (s *Server) initialize() error {
 	}
 
 	build := "unknown"
-	if m.Build != nil {
+	if !m.Build.IsZero() {
 		build = m.Build.Format("2006-01-02T15:04:05Z")
 	}
 	s.Logger.Infof("%s-driver version: %s (build: %s)",

--- a/protocol/driver.go
+++ b/protocol/driver.go
@@ -4,16 +4,18 @@ import (
 	"bytes"
 	"context"
 	"errors"
+	"strconv"
+	"strings"
 
 	"github.com/grpc-ecosystem/grpc-opentracing/go/otgrpc"
 	"github.com/opentracing/opentracing-go"
-	xcontext "golang.org/x/net/context"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 	serrors "gopkg.in/src-d/go-errors.v1"
 
 	"github.com/bblfsh/sdk/v3/driver"
+	"github.com/bblfsh/sdk/v3/driver/manifest"
 	"github.com/bblfsh/sdk/v3/uast/nodes"
 	"github.com/bblfsh/sdk/v3/uast/nodes/nodesproto"
 )
@@ -65,12 +67,19 @@ func DialOptions() []grpc.DialOption {
 	return opts
 }
 
+// RegisterDriver registers a v2 driver server on a given gRPC server.
 func RegisterDriver(srv *grpc.Server, d driver.Driver) {
-	RegisterDriverServer(srv, &driverServer{d: d})
+	s := &driverServer{d: d}
+	RegisterDriverServer(srv, s)
+	RegisterDriverHostServer(srv, s)
 }
 
+// AsDriver creates a v2 driver client for a given gRPC client.
 func AsDriver(cc *grpc.ClientConn) driver.Driver {
-	return &client{c: NewDriverClient(cc)}
+	return &client{
+		c: NewDriverClient(cc),
+		h: NewDriverHostClient(cc),
+	}
 }
 
 func toParseErrors(err error) []*ParseError {
@@ -91,7 +100,7 @@ type driverServer struct {
 }
 
 // Parse implements DriverServer.
-func (s *driverServer) Parse(rctx xcontext.Context, req *ParseRequest) (*ParseResponse, error) {
+func (s *driverServer) Parse(rctx context.Context, req *ParseRequest) (*ParseResponse, error) {
 	sp, ctx := opentracing.StartSpanFromContext(rctx, "bblfsh.server.Parse")
 	defer sp.Finish()
 
@@ -131,8 +140,37 @@ func (s *driverServer) Parse(rctx xcontext.Context, req *ParseRequest) (*ParseRe
 	return &resp, nil
 }
 
+func (s *driverServer) ServerVersion(rctx context.Context, _ *VersionRequest) (*VersionResponse, error) {
+	sp, ctx := opentracing.StartSpanFromContext(rctx, "bblfsh.server.Parse")
+	defer sp.Finish()
+
+	resp, err := s.d.Version(ctx)
+	if err != nil {
+		return nil, err
+	}
+	vers := Version(resp)
+	return &VersionResponse{Version: &vers}, nil
+}
+
+func (s *driverServer) SupportedLanguages(rctx context.Context, _ *SupportedLanguagesRequest) (*SupportedLanguagesResponse, error) {
+	sp, ctx := opentracing.StartSpanFromContext(rctx, "bblfsh.server.Parse")
+	defer sp.Finish()
+
+	resp, err := s.d.Languages(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	out := make([]*Manifest, 0, len(resp))
+	for _, m := range resp {
+		out = append(out, NewManifest(&m))
+	}
+	return &SupportedLanguagesResponse{Languages: out}, nil
+}
+
 type client struct {
 	c DriverClient
+	h DriverHostClient
 }
 
 // Parse implements DriverClient.
@@ -189,4 +227,112 @@ func (m *ParseResponse) Nodes() (nodes.Node, error) {
 		err = driver.ErrSyntax.Wrap(driver.JoinErrors(errs))
 	}
 	return ast, err
+}
+
+// Version implements DriverHostClient.
+func (c *client) Version(rctx context.Context) (driver.Version, error) {
+	sp, ctx := opentracing.StartSpanFromContext(rctx, "bblfsh.client.Version")
+	defer sp.Finish()
+
+	resp, err := c.h.ServerVersion(ctx, &VersionRequest{})
+	if err != nil {
+		return driver.Version{}, err
+	}
+	vers := (*driver.Version)(resp.Version)
+	return *vers, nil
+}
+
+// Languages implements DriverHostClient.
+func (c *client) Languages(rctx context.Context) ([]manifest.Manifest, error) {
+	sp, ctx := opentracing.StartSpanFromContext(rctx, "bblfsh.client.Languages")
+	defer sp.Finish()
+
+	resp, err := c.h.SupportedLanguages(ctx, &SupportedLanguagesRequest{})
+	if err != nil {
+		return nil, err
+	}
+	out := make([]manifest.Manifest, len(resp.Languages))
+	for i, m := range resp.Languages {
+		m.toNative(&out[i])
+	}
+	return out, nil
+}
+
+// NewManifest converts driver manifest to the corresponding protocol message.
+func NewManifest(m *manifest.Manifest) *Manifest {
+	dm := &Manifest{
+		Name:     m.Name,
+		Language: m.Language,
+		Aliases:  m.Aliases,
+		Features: make([]string, 0, len(m.Features)),
+	}
+	if m.Version != "" || !m.Build.IsZero() {
+		dm.Version = &Version{
+			Version: m.Version,
+			Build:   m.Build,
+		}
+	}
+	switch m.Status {
+	case manifest.Inactive:
+		dm.Status = DevelopmentStatus_Inactive
+	case manifest.Planning:
+		dm.Status = DevelopmentStatus_Planning
+	case manifest.PreAlpha:
+		dm.Status = DevelopmentStatus_PreAlpha
+	case manifest.Alpha:
+		dm.Status = DevelopmentStatus_Alpha
+	case manifest.Beta:
+		dm.Status = DevelopmentStatus_Beta
+	case manifest.Stable:
+		dm.Status = DevelopmentStatus_Stable
+	case manifest.Mature:
+		dm.Status = DevelopmentStatus_Mature
+	default:
+		st, _ := strconv.Atoi(string(m.Status))
+		dm.Status = DevelopmentStatus(st)
+	}
+	for _, f := range m.Features {
+		dm.Features = append(dm.Features, strings.ToLower(string(f)))
+	}
+	return dm
+}
+
+// ToNative converts the manifest message to the driver manifest used by the SDK.
+func (m *Manifest) toNative(dm *manifest.Manifest) {
+	dm.Name = m.Name
+	dm.Language = m.Language
+	dm.Aliases = m.Aliases
+	dm.Features = make([]manifest.Feature, 0, len(m.Features))
+	if m.Version != nil {
+		dm.Version = m.Version.Version
+		dm.Build = m.Version.Build
+	}
+	switch m.Status {
+	case DevelopmentStatus_Inactive:
+		dm.Status = manifest.Inactive
+	case DevelopmentStatus_Planning:
+		dm.Status = manifest.Planning
+	case DevelopmentStatus_PreAlpha:
+		dm.Status = manifest.PreAlpha
+	case DevelopmentStatus_Alpha:
+		dm.Status = manifest.Alpha
+	case DevelopmentStatus_Beta:
+		dm.Status = manifest.Beta
+	case DevelopmentStatus_Stable:
+		dm.Status = manifest.Stable
+	case DevelopmentStatus_Mature:
+		dm.Status = manifest.Mature
+	default:
+		dm.Status = manifest.DevelopmentStatus(strconv.Itoa(int(m.Status)))
+	}
+	for _, f := range m.Features {
+		dm.Features = append(dm.Features, manifest.Feature(strings.ToLower(f)))
+	}
+}
+
+// ToNative converts the manifest message to the driver manifest used by the SDK.
+func (m *Manifest) ToNative() *manifest.Manifest {
+	var dm manifest.Manifest
+	m.toNative(&dm)
+	return &dm
 }

--- a/protocol/driver.pb.go
+++ b/protocol/driver.pb.go
@@ -11,6 +11,12 @@
 		ParseRequest
 		ParseResponse
 		ParseError
+		Version
+		Manifest
+		VersionRequest
+		VersionResponse
+		SupportedLanguagesRequest
+		SupportedLanguagesResponse
 */
 package protocol
 
@@ -18,11 +24,14 @@ import proto "github.com/gogo/protobuf/proto"
 import fmt "fmt"
 import math "math"
 import _ "github.com/gogo/protobuf/gogoproto"
+import _ "github.com/golang/protobuf/ptypes/timestamp"
 
-import (
-	context "golang.org/x/net/context"
-	grpc "google.golang.org/grpc"
-)
+import time "time"
+
+import context "golang.org/x/net/context"
+import grpc "google.golang.org/grpc"
+
+import types "github.com/gogo/protobuf/types"
 
 import io "io"
 
@@ -30,6 +39,7 @@ import io "io"
 var _ = proto.Marshal
 var _ = fmt.Errorf
 var _ = math.Inf
+var _ = time.Kitchen
 
 // This is a compile-time assertion to ensure that this generated file
 // is compatible with the proto package it is being compiled against.
@@ -71,6 +81,42 @@ func (x Mode) String() string {
 	return proto.EnumName(Mode_name, int32(x))
 }
 func (Mode) EnumDescriptor() ([]byte, []int) { return fileDescriptorDriver, []int{0} }
+
+type DevelopmentStatus int32
+
+const (
+	DevelopmentStatus_Inactive DevelopmentStatus = 0
+	DevelopmentStatus_Planning DevelopmentStatus = 1
+	DevelopmentStatus_PreAlpha DevelopmentStatus = 2
+	DevelopmentStatus_Alpha    DevelopmentStatus = 3
+	DevelopmentStatus_Beta     DevelopmentStatus = 4
+	DevelopmentStatus_Stable   DevelopmentStatus = 5
+	DevelopmentStatus_Mature   DevelopmentStatus = 6
+)
+
+var DevelopmentStatus_name = map[int32]string{
+	0: "DEV_INACTIVE",
+	1: "DEV_PLANNING",
+	2: "DEV_PREALPHA",
+	3: "DEV_ALPHA",
+	4: "DEV_BETA",
+	5: "DEV_STABLE",
+	6: "DEV_MATURE",
+}
+var DevelopmentStatus_value = map[string]int32{
+	"DEV_INACTIVE": 0,
+	"DEV_PLANNING": 1,
+	"DEV_PREALPHA": 2,
+	"DEV_ALPHA":    3,
+	"DEV_BETA":     4,
+	"DEV_STABLE":   5,
+	"DEV_MATURE":   6,
+}
+
+func (x DevelopmentStatus) String() string {
+	return proto.EnumName(DevelopmentStatus_name, int32(x))
+}
+func (DevelopmentStatus) EnumDescriptor() ([]byte, []int) { return fileDescriptorDriver, []int{1} }
 
 // ParseRequest is a request to parse a file and get its UAST.
 type ParseRequest struct {
@@ -115,11 +161,83 @@ func (m *ParseError) String() string            { return proto.CompactTextString
 func (*ParseError) ProtoMessage()               {}
 func (*ParseError) Descriptor() ([]byte, []int) { return fileDescriptorDriver, []int{2} }
 
+type Version struct {
+	Version string    `protobuf:"bytes,1,opt,name=version,proto3" json:"version,omitempty"`
+	Build   time.Time `protobuf:"bytes,2,opt,name=build,stdtime" json:"build"`
+}
+
+func (m *Version) Reset()                    { *m = Version{} }
+func (m *Version) String() string            { return proto.CompactTextString(m) }
+func (*Version) ProtoMessage()               {}
+func (*Version) Descriptor() ([]byte, []int) { return fileDescriptorDriver, []int{3} }
+
+type Manifest struct {
+	// Name is a human-readable language or driver name.
+	Name string `protobuf:"bytes,1,opt,name=name,proto3" json:"name,omitempty"`
+	// Language is a Babelfish language identifier.
+	Language string `protobuf:"bytes,2,opt,name=language,proto3" json:"language,omitempty"`
+	// Aliases is a list of alternative language identifiers from Enry/Linguist.
+	Aliases []string `protobuf:"bytes,3,rep,name=aliases" json:"aliases,omitempty"`
+	// Version of the language driver.
+	Version *Version `protobuf:"bytes,4,opt,name=version" json:"version,omitempty"`
+	// Status of the driver development.
+	Status DevelopmentStatus `protobuf:"varint,5,opt,name=status,proto3,enum=gopkg.in.bblfsh.sdk.v2.protocol.DevelopmentStatus" json:"status,omitempty"`
+	// Features this driver supports.
+	Features []string `protobuf:"bytes,6,rep,name=features" json:"features,omitempty"`
+}
+
+func (m *Manifest) Reset()                    { *m = Manifest{} }
+func (m *Manifest) String() string            { return proto.CompactTextString(m) }
+func (*Manifest) ProtoMessage()               {}
+func (*Manifest) Descriptor() ([]byte, []int) { return fileDescriptorDriver, []int{4} }
+
+type VersionRequest struct {
+}
+
+func (m *VersionRequest) Reset()                    { *m = VersionRequest{} }
+func (m *VersionRequest) String() string            { return proto.CompactTextString(m) }
+func (*VersionRequest) ProtoMessage()               {}
+func (*VersionRequest) Descriptor() ([]byte, []int) { return fileDescriptorDriver, []int{5} }
+
+type VersionResponse struct {
+	Version *Version `protobuf:"bytes,1,opt,name=version" json:"version,omitempty"`
+}
+
+func (m *VersionResponse) Reset()                    { *m = VersionResponse{} }
+func (m *VersionResponse) String() string            { return proto.CompactTextString(m) }
+func (*VersionResponse) ProtoMessage()               {}
+func (*VersionResponse) Descriptor() ([]byte, []int) { return fileDescriptorDriver, []int{6} }
+
+type SupportedLanguagesRequest struct {
+}
+
+func (m *SupportedLanguagesRequest) Reset()                    { *m = SupportedLanguagesRequest{} }
+func (m *SupportedLanguagesRequest) String() string            { return proto.CompactTextString(m) }
+func (*SupportedLanguagesRequest) ProtoMessage()               {}
+func (*SupportedLanguagesRequest) Descriptor() ([]byte, []int) { return fileDescriptorDriver, []int{7} }
+
+type SupportedLanguagesResponse struct {
+	// Languages is a list of driver manifests for each language supported by the server.
+	Languages []*Manifest `protobuf:"bytes,1,rep,name=languages" json:"languages,omitempty"`
+}
+
+func (m *SupportedLanguagesResponse) Reset()                    { *m = SupportedLanguagesResponse{} }
+func (m *SupportedLanguagesResponse) String() string            { return proto.CompactTextString(m) }
+func (*SupportedLanguagesResponse) ProtoMessage()               {}
+func (*SupportedLanguagesResponse) Descriptor() ([]byte, []int) { return fileDescriptorDriver, []int{8} }
+
 func init() {
 	proto.RegisterType((*ParseRequest)(nil), "gopkg.in.bblfsh.sdk.v2.protocol.ParseRequest")
 	proto.RegisterType((*ParseResponse)(nil), "gopkg.in.bblfsh.sdk.v2.protocol.ParseResponse")
 	proto.RegisterType((*ParseError)(nil), "gopkg.in.bblfsh.sdk.v2.protocol.ParseError")
+	proto.RegisterType((*Version)(nil), "gopkg.in.bblfsh.sdk.v2.protocol.Version")
+	proto.RegisterType((*Manifest)(nil), "gopkg.in.bblfsh.sdk.v2.protocol.Manifest")
+	proto.RegisterType((*VersionRequest)(nil), "gopkg.in.bblfsh.sdk.v2.protocol.VersionRequest")
+	proto.RegisterType((*VersionResponse)(nil), "gopkg.in.bblfsh.sdk.v2.protocol.VersionResponse")
+	proto.RegisterType((*SupportedLanguagesRequest)(nil), "gopkg.in.bblfsh.sdk.v2.protocol.SupportedLanguagesRequest")
+	proto.RegisterType((*SupportedLanguagesResponse)(nil), "gopkg.in.bblfsh.sdk.v2.protocol.SupportedLanguagesResponse")
 	proto.RegisterEnum("gopkg.in.bblfsh.sdk.v2.protocol.Mode", Mode_name, Mode_value)
+	proto.RegisterEnum("gopkg.in.bblfsh.sdk.v2.protocol.DevelopmentStatus", DevelopmentStatus_name, DevelopmentStatus_value)
 }
 
 // Reference imports to suppress errors if they are not otherwise used.
@@ -190,6 +308,107 @@ var _Driver_serviceDesc = grpc.ServiceDesc{
 		{
 			MethodName: "Parse",
 			Handler:    _Driver_Parse_Handler,
+		},
+	},
+	Streams:  []grpc.StreamDesc{},
+	Metadata: "driver.proto",
+}
+
+// Client API for DriverHost service
+
+type DriverHostClient interface {
+	// ServerVersion returns version information of this server.
+	ServerVersion(ctx context.Context, in *VersionRequest, opts ...grpc.CallOption) (*VersionResponse, error)
+	// SupportedLanguages returns a list of languages supported by the server.
+	SupportedLanguages(ctx context.Context, in *SupportedLanguagesRequest, opts ...grpc.CallOption) (*SupportedLanguagesResponse, error)
+}
+
+type driverHostClient struct {
+	cc *grpc.ClientConn
+}
+
+func NewDriverHostClient(cc *grpc.ClientConn) DriverHostClient {
+	return &driverHostClient{cc}
+}
+
+func (c *driverHostClient) ServerVersion(ctx context.Context, in *VersionRequest, opts ...grpc.CallOption) (*VersionResponse, error) {
+	out := new(VersionResponse)
+	err := grpc.Invoke(ctx, "/gopkg.in.bblfsh.sdk.v2.protocol.DriverHost/ServerVersion", in, out, c.cc, opts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (c *driverHostClient) SupportedLanguages(ctx context.Context, in *SupportedLanguagesRequest, opts ...grpc.CallOption) (*SupportedLanguagesResponse, error) {
+	out := new(SupportedLanguagesResponse)
+	err := grpc.Invoke(ctx, "/gopkg.in.bblfsh.sdk.v2.protocol.DriverHost/SupportedLanguages", in, out, c.cc, opts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+// Server API for DriverHost service
+
+type DriverHostServer interface {
+	// ServerVersion returns version information of this server.
+	ServerVersion(context.Context, *VersionRequest) (*VersionResponse, error)
+	// SupportedLanguages returns a list of languages supported by the server.
+	SupportedLanguages(context.Context, *SupportedLanguagesRequest) (*SupportedLanguagesResponse, error)
+}
+
+func RegisterDriverHostServer(s *grpc.Server, srv DriverHostServer) {
+	s.RegisterService(&_DriverHost_serviceDesc, srv)
+}
+
+func _DriverHost_ServerVersion_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(VersionRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(DriverHostServer).ServerVersion(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: "/gopkg.in.bblfsh.sdk.v2.protocol.DriverHost/ServerVersion",
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(DriverHostServer).ServerVersion(ctx, req.(*VersionRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
+func _DriverHost_SupportedLanguages_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(SupportedLanguagesRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(DriverHostServer).SupportedLanguages(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: "/gopkg.in.bblfsh.sdk.v2.protocol.DriverHost/SupportedLanguages",
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(DriverHostServer).SupportedLanguages(ctx, req.(*SupportedLanguagesRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
+var _DriverHost_serviceDesc = grpc.ServiceDesc{
+	ServiceName: "gopkg.in.bblfsh.sdk.v2.protocol.DriverHost",
+	HandlerType: (*DriverHostServer)(nil),
+	Methods: []grpc.MethodDesc{
+		{
+			MethodName: "ServerVersion",
+			Handler:    _DriverHost_ServerVersion_Handler,
+		},
+		{
+			MethodName: "SupportedLanguages",
+			Handler:    _DriverHost_SupportedLanguages_Handler,
 		},
 	},
 	Streams:  []grpc.StreamDesc{},
@@ -303,24 +522,207 @@ func (m *ParseError) MarshalTo(dAtA []byte) (int, error) {
 	return i, nil
 }
 
-func encodeFixed64Driver(dAtA []byte, offset int, v uint64) int {
-	dAtA[offset] = uint8(v)
-	dAtA[offset+1] = uint8(v >> 8)
-	dAtA[offset+2] = uint8(v >> 16)
-	dAtA[offset+3] = uint8(v >> 24)
-	dAtA[offset+4] = uint8(v >> 32)
-	dAtA[offset+5] = uint8(v >> 40)
-	dAtA[offset+6] = uint8(v >> 48)
-	dAtA[offset+7] = uint8(v >> 56)
-	return offset + 8
+func (m *Version) Marshal() (dAtA []byte, err error) {
+	size := m.ProtoSize()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalTo(dAtA)
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
 }
-func encodeFixed32Driver(dAtA []byte, offset int, v uint32) int {
-	dAtA[offset] = uint8(v)
-	dAtA[offset+1] = uint8(v >> 8)
-	dAtA[offset+2] = uint8(v >> 16)
-	dAtA[offset+3] = uint8(v >> 24)
-	return offset + 4
+
+func (m *Version) MarshalTo(dAtA []byte) (int, error) {
+	var i int
+	_ = i
+	var l int
+	_ = l
+	if len(m.Version) > 0 {
+		dAtA[i] = 0xa
+		i++
+		i = encodeVarintDriver(dAtA, i, uint64(len(m.Version)))
+		i += copy(dAtA[i:], m.Version)
+	}
+	dAtA[i] = 0x12
+	i++
+	i = encodeVarintDriver(dAtA, i, uint64(types.SizeOfStdTime(m.Build)))
+	n1, err := types.StdTimeMarshalTo(m.Build, dAtA[i:])
+	if err != nil {
+		return 0, err
+	}
+	i += n1
+	return i, nil
 }
+
+func (m *Manifest) Marshal() (dAtA []byte, err error) {
+	size := m.ProtoSize()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalTo(dAtA)
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *Manifest) MarshalTo(dAtA []byte) (int, error) {
+	var i int
+	_ = i
+	var l int
+	_ = l
+	if len(m.Name) > 0 {
+		dAtA[i] = 0xa
+		i++
+		i = encodeVarintDriver(dAtA, i, uint64(len(m.Name)))
+		i += copy(dAtA[i:], m.Name)
+	}
+	if len(m.Language) > 0 {
+		dAtA[i] = 0x12
+		i++
+		i = encodeVarintDriver(dAtA, i, uint64(len(m.Language)))
+		i += copy(dAtA[i:], m.Language)
+	}
+	if len(m.Aliases) > 0 {
+		for _, s := range m.Aliases {
+			dAtA[i] = 0x1a
+			i++
+			l = len(s)
+			for l >= 1<<7 {
+				dAtA[i] = uint8(uint64(l)&0x7f | 0x80)
+				l >>= 7
+				i++
+			}
+			dAtA[i] = uint8(l)
+			i++
+			i += copy(dAtA[i:], s)
+		}
+	}
+	if m.Version != nil {
+		dAtA[i] = 0x22
+		i++
+		i = encodeVarintDriver(dAtA, i, uint64(m.Version.ProtoSize()))
+		n2, err := m.Version.MarshalTo(dAtA[i:])
+		if err != nil {
+			return 0, err
+		}
+		i += n2
+	}
+	if m.Status != 0 {
+		dAtA[i] = 0x28
+		i++
+		i = encodeVarintDriver(dAtA, i, uint64(m.Status))
+	}
+	if len(m.Features) > 0 {
+		for _, s := range m.Features {
+			dAtA[i] = 0x32
+			i++
+			l = len(s)
+			for l >= 1<<7 {
+				dAtA[i] = uint8(uint64(l)&0x7f | 0x80)
+				l >>= 7
+				i++
+			}
+			dAtA[i] = uint8(l)
+			i++
+			i += copy(dAtA[i:], s)
+		}
+	}
+	return i, nil
+}
+
+func (m *VersionRequest) Marshal() (dAtA []byte, err error) {
+	size := m.ProtoSize()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalTo(dAtA)
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *VersionRequest) MarshalTo(dAtA []byte) (int, error) {
+	var i int
+	_ = i
+	var l int
+	_ = l
+	return i, nil
+}
+
+func (m *VersionResponse) Marshal() (dAtA []byte, err error) {
+	size := m.ProtoSize()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalTo(dAtA)
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *VersionResponse) MarshalTo(dAtA []byte) (int, error) {
+	var i int
+	_ = i
+	var l int
+	_ = l
+	if m.Version != nil {
+		dAtA[i] = 0xa
+		i++
+		i = encodeVarintDriver(dAtA, i, uint64(m.Version.ProtoSize()))
+		n3, err := m.Version.MarshalTo(dAtA[i:])
+		if err != nil {
+			return 0, err
+		}
+		i += n3
+	}
+	return i, nil
+}
+
+func (m *SupportedLanguagesRequest) Marshal() (dAtA []byte, err error) {
+	size := m.ProtoSize()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalTo(dAtA)
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *SupportedLanguagesRequest) MarshalTo(dAtA []byte) (int, error) {
+	var i int
+	_ = i
+	var l int
+	_ = l
+	return i, nil
+}
+
+func (m *SupportedLanguagesResponse) Marshal() (dAtA []byte, err error) {
+	size := m.ProtoSize()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalTo(dAtA)
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *SupportedLanguagesResponse) MarshalTo(dAtA []byte) (int, error) {
+	var i int
+	_ = i
+	var l int
+	_ = l
+	if len(m.Languages) > 0 {
+		for _, msg := range m.Languages {
+			dAtA[i] = 0xa
+			i++
+			i = encodeVarintDriver(dAtA, i, uint64(msg.ProtoSize()))
+			n, err := msg.MarshalTo(dAtA[i:])
+			if err != nil {
+				return 0, err
+			}
+			i += n
+		}
+	}
+	return i, nil
+}
+
 func encodeVarintDriver(dAtA []byte, offset int, v uint64) int {
 	for v >= 1<<7 {
 		dAtA[offset] = uint8(v&0x7f | 0x80)
@@ -377,6 +779,85 @@ func (m *ParseError) ProtoSize() (n int) {
 	l = len(m.Text)
 	if l > 0 {
 		n += 1 + l + sovDriver(uint64(l))
+	}
+	return n
+}
+
+func (m *Version) ProtoSize() (n int) {
+	var l int
+	_ = l
+	l = len(m.Version)
+	if l > 0 {
+		n += 1 + l + sovDriver(uint64(l))
+	}
+	l = types.SizeOfStdTime(m.Build)
+	n += 1 + l + sovDriver(uint64(l))
+	return n
+}
+
+func (m *Manifest) ProtoSize() (n int) {
+	var l int
+	_ = l
+	l = len(m.Name)
+	if l > 0 {
+		n += 1 + l + sovDriver(uint64(l))
+	}
+	l = len(m.Language)
+	if l > 0 {
+		n += 1 + l + sovDriver(uint64(l))
+	}
+	if len(m.Aliases) > 0 {
+		for _, s := range m.Aliases {
+			l = len(s)
+			n += 1 + l + sovDriver(uint64(l))
+		}
+	}
+	if m.Version != nil {
+		l = m.Version.ProtoSize()
+		n += 1 + l + sovDriver(uint64(l))
+	}
+	if m.Status != 0 {
+		n += 1 + sovDriver(uint64(m.Status))
+	}
+	if len(m.Features) > 0 {
+		for _, s := range m.Features {
+			l = len(s)
+			n += 1 + l + sovDriver(uint64(l))
+		}
+	}
+	return n
+}
+
+func (m *VersionRequest) ProtoSize() (n int) {
+	var l int
+	_ = l
+	return n
+}
+
+func (m *VersionResponse) ProtoSize() (n int) {
+	var l int
+	_ = l
+	if m.Version != nil {
+		l = m.Version.ProtoSize()
+		n += 1 + l + sovDriver(uint64(l))
+	}
+	return n
+}
+
+func (m *SupportedLanguagesRequest) ProtoSize() (n int) {
+	var l int
+	_ = l
+	return n
+}
+
+func (m *SupportedLanguagesResponse) ProtoSize() (n int) {
+	var l int
+	_ = l
+	if len(m.Languages) > 0 {
+		for _, e := range m.Languages {
+			l = e.ProtoSize()
+			n += 1 + l + sovDriver(uint64(l))
+		}
 	}
 	return n
 }
@@ -770,6 +1251,597 @@ func (m *ParseError) Unmarshal(dAtA []byte) error {
 	}
 	return nil
 }
+func (m *Version) Unmarshal(dAtA []byte) error {
+	l := len(dAtA)
+	iNdEx := 0
+	for iNdEx < l {
+		preIndex := iNdEx
+		var wire uint64
+		for shift := uint(0); ; shift += 7 {
+			if shift >= 64 {
+				return ErrIntOverflowDriver
+			}
+			if iNdEx >= l {
+				return io.ErrUnexpectedEOF
+			}
+			b := dAtA[iNdEx]
+			iNdEx++
+			wire |= (uint64(b) & 0x7F) << shift
+			if b < 0x80 {
+				break
+			}
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		if wireType == 4 {
+			return fmt.Errorf("proto: Version: wiretype end group for non-group")
+		}
+		if fieldNum <= 0 {
+			return fmt.Errorf("proto: Version: illegal tag %d (wire type %d)", fieldNum, wire)
+		}
+		switch fieldNum {
+		case 1:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Version", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowDriver
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= (uint64(b) & 0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return ErrInvalidLengthDriver
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.Version = string(dAtA[iNdEx:postIndex])
+			iNdEx = postIndex
+		case 2:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Build", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowDriver
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				msglen |= (int(b) & 0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if msglen < 0 {
+				return ErrInvalidLengthDriver
+			}
+			postIndex := iNdEx + msglen
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			if err := types.StdTimeUnmarshal(&m.Build, dAtA[iNdEx:postIndex]); err != nil {
+				return err
+			}
+			iNdEx = postIndex
+		default:
+			iNdEx = preIndex
+			skippy, err := skipDriver(dAtA[iNdEx:])
+			if err != nil {
+				return err
+			}
+			if skippy < 0 {
+				return ErrInvalidLengthDriver
+			}
+			if (iNdEx + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			iNdEx += skippy
+		}
+	}
+
+	if iNdEx > l {
+		return io.ErrUnexpectedEOF
+	}
+	return nil
+}
+func (m *Manifest) Unmarshal(dAtA []byte) error {
+	l := len(dAtA)
+	iNdEx := 0
+	for iNdEx < l {
+		preIndex := iNdEx
+		var wire uint64
+		for shift := uint(0); ; shift += 7 {
+			if shift >= 64 {
+				return ErrIntOverflowDriver
+			}
+			if iNdEx >= l {
+				return io.ErrUnexpectedEOF
+			}
+			b := dAtA[iNdEx]
+			iNdEx++
+			wire |= (uint64(b) & 0x7F) << shift
+			if b < 0x80 {
+				break
+			}
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		if wireType == 4 {
+			return fmt.Errorf("proto: Manifest: wiretype end group for non-group")
+		}
+		if fieldNum <= 0 {
+			return fmt.Errorf("proto: Manifest: illegal tag %d (wire type %d)", fieldNum, wire)
+		}
+		switch fieldNum {
+		case 1:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Name", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowDriver
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= (uint64(b) & 0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return ErrInvalidLengthDriver
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.Name = string(dAtA[iNdEx:postIndex])
+			iNdEx = postIndex
+		case 2:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Language", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowDriver
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= (uint64(b) & 0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return ErrInvalidLengthDriver
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.Language = string(dAtA[iNdEx:postIndex])
+			iNdEx = postIndex
+		case 3:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Aliases", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowDriver
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= (uint64(b) & 0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return ErrInvalidLengthDriver
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.Aliases = append(m.Aliases, string(dAtA[iNdEx:postIndex]))
+			iNdEx = postIndex
+		case 4:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Version", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowDriver
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				msglen |= (int(b) & 0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if msglen < 0 {
+				return ErrInvalidLengthDriver
+			}
+			postIndex := iNdEx + msglen
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			if m.Version == nil {
+				m.Version = &Version{}
+			}
+			if err := m.Version.Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
+				return err
+			}
+			iNdEx = postIndex
+		case 5:
+			if wireType != 0 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Status", wireType)
+			}
+			m.Status = 0
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowDriver
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				m.Status |= (DevelopmentStatus(b) & 0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+		case 6:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Features", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowDriver
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= (uint64(b) & 0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return ErrInvalidLengthDriver
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.Features = append(m.Features, string(dAtA[iNdEx:postIndex]))
+			iNdEx = postIndex
+		default:
+			iNdEx = preIndex
+			skippy, err := skipDriver(dAtA[iNdEx:])
+			if err != nil {
+				return err
+			}
+			if skippy < 0 {
+				return ErrInvalidLengthDriver
+			}
+			if (iNdEx + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			iNdEx += skippy
+		}
+	}
+
+	if iNdEx > l {
+		return io.ErrUnexpectedEOF
+	}
+	return nil
+}
+func (m *VersionRequest) Unmarshal(dAtA []byte) error {
+	l := len(dAtA)
+	iNdEx := 0
+	for iNdEx < l {
+		preIndex := iNdEx
+		var wire uint64
+		for shift := uint(0); ; shift += 7 {
+			if shift >= 64 {
+				return ErrIntOverflowDriver
+			}
+			if iNdEx >= l {
+				return io.ErrUnexpectedEOF
+			}
+			b := dAtA[iNdEx]
+			iNdEx++
+			wire |= (uint64(b) & 0x7F) << shift
+			if b < 0x80 {
+				break
+			}
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		if wireType == 4 {
+			return fmt.Errorf("proto: VersionRequest: wiretype end group for non-group")
+		}
+		if fieldNum <= 0 {
+			return fmt.Errorf("proto: VersionRequest: illegal tag %d (wire type %d)", fieldNum, wire)
+		}
+		switch fieldNum {
+		default:
+			iNdEx = preIndex
+			skippy, err := skipDriver(dAtA[iNdEx:])
+			if err != nil {
+				return err
+			}
+			if skippy < 0 {
+				return ErrInvalidLengthDriver
+			}
+			if (iNdEx + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			iNdEx += skippy
+		}
+	}
+
+	if iNdEx > l {
+		return io.ErrUnexpectedEOF
+	}
+	return nil
+}
+func (m *VersionResponse) Unmarshal(dAtA []byte) error {
+	l := len(dAtA)
+	iNdEx := 0
+	for iNdEx < l {
+		preIndex := iNdEx
+		var wire uint64
+		for shift := uint(0); ; shift += 7 {
+			if shift >= 64 {
+				return ErrIntOverflowDriver
+			}
+			if iNdEx >= l {
+				return io.ErrUnexpectedEOF
+			}
+			b := dAtA[iNdEx]
+			iNdEx++
+			wire |= (uint64(b) & 0x7F) << shift
+			if b < 0x80 {
+				break
+			}
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		if wireType == 4 {
+			return fmt.Errorf("proto: VersionResponse: wiretype end group for non-group")
+		}
+		if fieldNum <= 0 {
+			return fmt.Errorf("proto: VersionResponse: illegal tag %d (wire type %d)", fieldNum, wire)
+		}
+		switch fieldNum {
+		case 1:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Version", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowDriver
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				msglen |= (int(b) & 0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if msglen < 0 {
+				return ErrInvalidLengthDriver
+			}
+			postIndex := iNdEx + msglen
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			if m.Version == nil {
+				m.Version = &Version{}
+			}
+			if err := m.Version.Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
+				return err
+			}
+			iNdEx = postIndex
+		default:
+			iNdEx = preIndex
+			skippy, err := skipDriver(dAtA[iNdEx:])
+			if err != nil {
+				return err
+			}
+			if skippy < 0 {
+				return ErrInvalidLengthDriver
+			}
+			if (iNdEx + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			iNdEx += skippy
+		}
+	}
+
+	if iNdEx > l {
+		return io.ErrUnexpectedEOF
+	}
+	return nil
+}
+func (m *SupportedLanguagesRequest) Unmarshal(dAtA []byte) error {
+	l := len(dAtA)
+	iNdEx := 0
+	for iNdEx < l {
+		preIndex := iNdEx
+		var wire uint64
+		for shift := uint(0); ; shift += 7 {
+			if shift >= 64 {
+				return ErrIntOverflowDriver
+			}
+			if iNdEx >= l {
+				return io.ErrUnexpectedEOF
+			}
+			b := dAtA[iNdEx]
+			iNdEx++
+			wire |= (uint64(b) & 0x7F) << shift
+			if b < 0x80 {
+				break
+			}
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		if wireType == 4 {
+			return fmt.Errorf("proto: SupportedLanguagesRequest: wiretype end group for non-group")
+		}
+		if fieldNum <= 0 {
+			return fmt.Errorf("proto: SupportedLanguagesRequest: illegal tag %d (wire type %d)", fieldNum, wire)
+		}
+		switch fieldNum {
+		default:
+			iNdEx = preIndex
+			skippy, err := skipDriver(dAtA[iNdEx:])
+			if err != nil {
+				return err
+			}
+			if skippy < 0 {
+				return ErrInvalidLengthDriver
+			}
+			if (iNdEx + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			iNdEx += skippy
+		}
+	}
+
+	if iNdEx > l {
+		return io.ErrUnexpectedEOF
+	}
+	return nil
+}
+func (m *SupportedLanguagesResponse) Unmarshal(dAtA []byte) error {
+	l := len(dAtA)
+	iNdEx := 0
+	for iNdEx < l {
+		preIndex := iNdEx
+		var wire uint64
+		for shift := uint(0); ; shift += 7 {
+			if shift >= 64 {
+				return ErrIntOverflowDriver
+			}
+			if iNdEx >= l {
+				return io.ErrUnexpectedEOF
+			}
+			b := dAtA[iNdEx]
+			iNdEx++
+			wire |= (uint64(b) & 0x7F) << shift
+			if b < 0x80 {
+				break
+			}
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		if wireType == 4 {
+			return fmt.Errorf("proto: SupportedLanguagesResponse: wiretype end group for non-group")
+		}
+		if fieldNum <= 0 {
+			return fmt.Errorf("proto: SupportedLanguagesResponse: illegal tag %d (wire type %d)", fieldNum, wire)
+		}
+		switch fieldNum {
+		case 1:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Languages", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowDriver
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				msglen |= (int(b) & 0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if msglen < 0 {
+				return ErrInvalidLengthDriver
+			}
+			postIndex := iNdEx + msglen
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.Languages = append(m.Languages, &Manifest{})
+			if err := m.Languages[len(m.Languages)-1].Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
+				return err
+			}
+			iNdEx = postIndex
+		default:
+			iNdEx = preIndex
+			skippy, err := skipDriver(dAtA[iNdEx:])
+			if err != nil {
+				return err
+			}
+			if skippy < 0 {
+				return ErrInvalidLengthDriver
+			}
+			if (iNdEx + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			iNdEx += skippy
+		}
+	}
+
+	if iNdEx > l {
+		return io.ErrUnexpectedEOF
+	}
+	return nil
+}
 func skipDriver(dAtA []byte) (n int, err error) {
 	l := len(dAtA)
 	iNdEx := 0
@@ -878,34 +1950,59 @@ var (
 func init() { proto.RegisterFile("driver.proto", fileDescriptorDriver) }
 
 var fileDescriptorDriver = []byte{
-	// 457 bytes of a gzipped FileDescriptorProto
-	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0x8c, 0x52, 0xcd, 0x8e, 0x93, 0x50,
-	0x14, 0xee, 0x9d, 0x56, 0x6c, 0xef, 0x30, 0x4a, 0xee, 0xc2, 0x10, 0x62, 0x10, 0x9b, 0x98, 0x34,
-	0x9a, 0x61, 0x92, 0xba, 0x72, 0x89, 0x05, 0x93, 0x49, 0x2c, 0x6d, 0x28, 0xba, 0x70, 0x63, 0xf8,
-	0x39, 0x30, 0x64, 0x28, 0x17, 0xb9, 0x97, 0xc6, 0x07, 0x70, 0xc5, 0x2b, 0x18, 0xa2, 0x8f, 0x33,
-	0x4b, 0x1f, 0x41, 0xeb, 0x8b, 0x18, 0x2e, 0xad, 0xee, 0x9c, 0xd9, 0x7d, 0xdf, 0xfd, 0xce, 0x97,
-	0xf3, 0x9d, 0x73, 0x0f, 0x96, 0xe3, 0x2a, 0xdb, 0x41, 0x65, 0x96, 0x15, 0xe5, 0x94, 0x3c, 0x49,
-	0x69, 0x79, 0x9d, 0x9a, 0x59, 0x61, 0x86, 0x61, 0x9e, 0xb0, 0x2b, 0x93, 0xc5, 0xd7, 0xe6, 0x6e,
-	0xde, 0xab, 0x11, 0xcd, 0xb5, 0xf3, 0x34, 0xe3, 0x57, 0x75, 0x68, 0x46, 0x74, 0x7b, 0x91, 0xd2,
-	0x94, 0x5e, 0x08, 0x25, 0xac, 0x13, 0xc1, 0x04, 0x11, 0xa8, 0x77, 0x4c, 0xbf, 0x22, 0x2c, 0xaf,
-	0x83, 0x8a, 0x81, 0x07, 0x9f, 0x6a, 0x60, 0x9c, 0xa8, 0xf8, 0x7e, 0x44, 0x0b, 0x0e, 0x05, 0x57,
-	0x91, 0x81, 0x66, 0x13, 0xef, 0x48, 0x89, 0x86, 0xc7, 0x79, 0x50, 0xa4, 0x75, 0x90, 0x82, 0x7a,
-	0x22, 0xa4, 0xbf, 0xbc, 0xd3, 0x92, 0x2c, 0x87, 0x22, 0xd8, 0x82, 0x3a, 0xec, 0xb5, 0x23, 0x27,
-	0xaf, 0xf0, 0x68, 0x4b, 0x63, 0x50, 0x47, 0x06, 0x9a, 0x3d, 0x98, 0x3f, 0x33, 0x6f, 0x99, 0xc0,
-	0x5c, 0xd2, 0x18, 0x3c, 0x61, 0x99, 0x7e, 0x41, 0xf8, 0xec, 0x90, 0x8e, 0x95, 0xb4, 0x60, 0x40,
-	0x08, 0x1e, 0xd5, 0x01, 0xeb, 0xb3, 0xc9, 0x9e, 0xc0, 0xff, 0x0d, 0xb6, 0xc0, 0x12, 0x54, 0x15,
-	0xad, 0x98, 0x3a, 0x34, 0x86, 0xb3, 0xd3, 0xf9, 0x8b, 0x5b, 0xdb, 0x8b, 0x7e, 0x4e, 0xe7, 0xf1,
-	0x0e, 0xd6, 0xa9, 0x81, 0xf1, 0xbf, 0xd7, 0x2e, 0x02, 0x87, 0xcf, 0xc7, 0xf5, 0x08, 0xfc, 0xfc,
-	0x1b, 0xc2, 0xa3, 0x2e, 0x37, 0x79, 0x8a, 0x65, 0xdb, 0x79, 0x63, 0xbd, 0x7b, 0xeb, 0x7f, 0x5c,
-	0xae, 0x6c, 0x47, 0x19, 0x68, 0x0f, 0x9b, 0xd6, 0x38, 0xb5, 0x21, 0x09, 0xea, 0x9c, 0x8b, 0x92,
-	0x47, 0x58, 0x72, 0x2d, 0xff, 0xf2, 0xbd, 0xa3, 0x20, 0x0d, 0x37, 0xad, 0x21, 0xb9, 0x01, 0xcf,
-	0x76, 0x40, 0xa6, 0x58, 0x5e, 0x7b, 0xce, 0xda, 0x5b, 0x2d, 0x9c, 0xcd, 0xc6, 0xb1, 0x95, 0x13,
-	0x4d, 0x69, 0x5a, 0x43, 0x5e, 0x57, 0x50, 0x56, 0x34, 0x02, 0xc6, 0x20, 0x26, 0x8f, 0xf1, 0xc4,
-	0x72, 0xdd, 0x95, 0x6f, 0xf9, 0x8e, 0xad, 0x8c, 0xb4, 0xb3, 0xa6, 0x35, 0x26, 0x56, 0x51, 0x50,
-	0x1e, 0x70, 0x88, 0xbb, 0x45, 0x6c, 0x9c, 0xa5, 0xe5, 0xfa, 0x97, 0x0b, 0x65, 0xac, 0xc9, 0x4d,
-	0x6b, 0x8c, 0x37, 0xb0, 0x0d, 0x0a, 0x9e, 0x45, 0xf3, 0x12, 0x4b, 0xb6, 0x38, 0x24, 0x92, 0xe0,
-	0x7b, 0x62, 0x1a, 0x72, 0x7e, 0xb7, 0x5d, 0x1c, 0x2e, 0x43, 0x33, 0xef, 0x5a, 0xde, 0x7f, 0xd5,
-	0x6b, 0xfd, 0xe6, 0x97, 0x3e, 0xb8, 0xd9, 0xeb, 0xe8, 0xc7, 0x5e, 0x47, 0x3f, 0xf7, 0xfa, 0xe0,
-	0xfb, 0x6f, 0x1d, 0x7d, 0x18, 0x1f, 0xab, 0x43, 0x49, 0xa0, 0x97, 0x7f, 0x02, 0x00, 0x00, 0xff,
-	0xff, 0x64, 0x59, 0x48, 0x92, 0xe1, 0x02, 0x00, 0x00,
+	// 852 bytes of a gzipped FileDescriptorProto
+	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0x9c, 0x54, 0xcf, 0x6f, 0xe3, 0x44,
+	0x14, 0x8e, 0xd3, 0x24, 0x4d, 0x5e, 0xd3, 0x5d, 0x33, 0x87, 0x95, 0x31, 0x28, 0x35, 0x91, 0x90,
+	0xca, 0xa2, 0x75, 0x51, 0x38, 0xb1, 0x9c, 0x9c, 0xc6, 0xec, 0x06, 0x25, 0x69, 0xe4, 0xa4, 0x3d,
+	0x70, 0xa9, 0x26, 0xc9, 0x8b, 0x6b, 0xad, 0xe3, 0x31, 0x9e, 0x71, 0xc4, 0x91, 0x03, 0xa7, 0x48,
+	0x48, 0x7b, 0x47, 0x11, 0xfc, 0x39, 0x3d, 0xf2, 0x0f, 0xf0, 0xab, 0xfc, 0x23, 0xc8, 0x33, 0x76,
+	0x23, 0xb4, 0xb0, 0xa9, 0xf6, 0x36, 0xcf, 0xdf, 0x7c, 0x7e, 0xdf, 0x7c, 0xef, 0x9b, 0x81, 0xe6,
+	0x22, 0x09, 0xd6, 0x98, 0xd8, 0x71, 0xc2, 0x04, 0x23, 0x27, 0x3e, 0x8b, 0x5f, 0xf9, 0x76, 0x10,
+	0xd9, 0xb3, 0x59, 0xb8, 0xe4, 0x37, 0x36, 0x5f, 0xbc, 0xb2, 0xd7, 0x1d, 0x85, 0xce, 0x59, 0x68,
+	0x3e, 0xf3, 0x03, 0x71, 0x93, 0xce, 0xec, 0x39, 0x5b, 0x9d, 0xf9, 0xcc, 0x67, 0x67, 0x12, 0x99,
+	0xa5, 0x4b, 0x59, 0xc9, 0x42, 0xae, 0x14, 0xc3, 0x3c, 0xf1, 0x19, 0xf3, 0x43, 0xdc, 0xed, 0x12,
+	0xc1, 0x0a, 0xb9, 0xa0, 0xab, 0x58, 0x6d, 0x68, 0xff, 0xa4, 0x41, 0x73, 0x4c, 0x13, 0x8e, 0x1e,
+	0x7e, 0x9b, 0x22, 0x17, 0xc4, 0x80, 0xc3, 0x39, 0x8b, 0x04, 0x46, 0xc2, 0xd0, 0x2c, 0xed, 0xb4,
+	0xe1, 0x15, 0x25, 0x31, 0xa1, 0x1e, 0xd2, 0xc8, 0x4f, 0xa9, 0x8f, 0x46, 0x59, 0x42, 0xf7, 0x75,
+	0x86, 0x2d, 0x83, 0x10, 0x23, 0xba, 0x42, 0xe3, 0x40, 0x61, 0x45, 0x4d, 0xbe, 0x80, 0xca, 0x8a,
+	0x2d, 0xd0, 0xa8, 0x58, 0xda, 0xe9, 0xa3, 0xce, 0xc7, 0xf6, 0x9e, 0x23, 0xda, 0x43, 0xb6, 0x40,
+	0x4f, 0x52, 0xda, 0x3f, 0x68, 0x70, 0x9c, 0xab, 0xe3, 0x31, 0x8b, 0x38, 0x12, 0x02, 0x95, 0x94,
+	0x72, 0xa5, 0xad, 0xe9, 0xc9, 0xf5, 0x5b, 0x85, 0x9d, 0x43, 0x0d, 0x93, 0x84, 0x25, 0xdc, 0x38,
+	0xb0, 0x0e, 0x4e, 0x8f, 0x3a, 0x9f, 0xee, 0x6d, 0x2f, 0xfb, 0xb9, 0x19, 0xc7, 0xcb, 0xa9, 0x6d,
+	0x0b, 0x60, 0xf7, 0x35, 0x93, 0x20, 0xf0, 0xbb, 0xc2, 0x1e, 0xb9, 0x6e, 0x5f, 0xc3, 0xe1, 0x15,
+	0x26, 0x3c, 0x60, 0x51, 0x66, 0xe0, 0x5a, 0x2d, 0x0b, 0x03, 0xf3, 0x92, 0x3c, 0x87, 0xea, 0x2c,
+	0x0d, 0xc2, 0x85, 0x14, 0x79, 0xd4, 0x31, 0x6d, 0x35, 0x1c, 0xbb, 0x18, 0x8e, 0x3d, 0x2d, 0x86,
+	0xd3, 0xad, 0xdf, 0xfe, 0x7e, 0x52, 0x7a, 0xfd, 0xc7, 0x89, 0xe6, 0x29, 0x4a, 0xfb, 0xfb, 0x32,
+	0xd4, 0x87, 0x34, 0x0a, 0x96, 0xd9, 0x8c, 0x08, 0x54, 0xa4, 0xd3, 0xb9, 0x02, 0xe9, 0xf2, 0xdb,
+	0x4c, 0x30, 0xe0, 0x90, 0x86, 0x01, 0xe5, 0xa8, 0x5c, 0x68, 0x78, 0x45, 0x49, 0xba, 0x3b, 0xb1,
+	0x15, 0x29, 0xea, 0x74, 0xaf, 0x3f, 0xf9, 0x39, 0x77, 0xc7, 0xfa, 0x1a, 0x6a, 0x5c, 0x50, 0x91,
+	0x72, 0xa3, 0x2a, 0x27, 0xdc, 0xd9, 0xfb, 0x8b, 0x1e, 0xae, 0x31, 0x64, 0xf1, 0x0a, 0x23, 0x31,
+	0x91, 0x4c, 0x2f, 0xff, 0x83, 0xcc, 0x11, 0x52, 0x91, 0x26, 0xc8, 0x8d, 0x9a, 0x94, 0x7a, 0x5f,
+	0xb7, 0x75, 0x78, 0x54, 0xf4, 0x56, 0x59, 0x6d, 0x5f, 0xc2, 0xe3, 0xfb, 0x2f, 0x79, 0x3e, 0xba,
+	0xff, 0x76, 0xff, 0x5d, 0x0e, 0xd4, 0xfe, 0x00, 0xde, 0x9f, 0xa4, 0x71, 0xcc, 0x12, 0x81, 0x8b,
+	0x41, 0xee, 0x21, 0x2f, 0x7a, 0x22, 0x98, 0xff, 0x05, 0xe6, 0xed, 0x5f, 0x40, 0xa3, 0x70, 0x9d,
+	0x1b, 0x9a, 0x4c, 0xdc, 0x27, 0xfb, 0x03, 0x9f, 0xcf, 0xd5, 0xdb, 0x71, 0x9f, 0xfe, 0xac, 0x41,
+	0x25, 0xbb, 0x08, 0xe4, 0x23, 0x68, 0xf6, 0xdc, 0xaf, 0x9c, 0xcb, 0xc1, 0xf4, 0x7a, 0x78, 0xd1,
+	0x73, 0xf5, 0x92, 0xf9, 0x78, 0xb3, 0xb5, 0x8e, 0x7a, 0xb8, 0xa4, 0x69, 0x28, 0xe4, 0x96, 0x27,
+	0x50, 0x1b, 0x39, 0xd3, 0xfe, 0x95, 0xab, 0x6b, 0x26, 0x6c, 0xb6, 0x56, 0x6d, 0x44, 0x45, 0xb0,
+	0x46, 0xd2, 0x86, 0xe6, 0xd8, 0x73, 0xc7, 0xde, 0xc5, 0xb9, 0x3b, 0x99, 0xb8, 0x3d, 0xbd, 0x6c,
+	0xea, 0x9b, 0xad, 0xd5, 0x1c, 0x27, 0x18, 0x27, 0x6c, 0x8e, 0x9c, 0xe3, 0x82, 0x7c, 0x08, 0x0d,
+	0x67, 0x34, 0xba, 0x98, 0x3a, 0x53, 0xb7, 0xa7, 0x57, 0xcc, 0xe3, 0xcd, 0xd6, 0x6a, 0x38, 0x51,
+	0xc4, 0x04, 0x15, 0xb8, 0xc8, 0xc6, 0x31, 0x71, 0x87, 0xce, 0x68, 0xda, 0x3f, 0xd7, 0xeb, 0x66,
+	0x73, 0xb3, 0xb5, 0xea, 0x13, 0x5c, 0xd1, 0x48, 0x04, 0xf3, 0xa7, 0xbf, 0x69, 0xf0, 0xde, 0x1b,
+	0x83, 0x24, 0xad, 0x4c, 0xee, 0xd5, 0x75, 0x7f, 0xe4, 0x9c, 0x4b, 0x45, 0x25, 0xc5, 0xea, 0x47,
+	0x74, 0x2e, 0x35, 0xe5, 0xf8, 0x78, 0xe0, 0x8c, 0x46, 0xfd, 0xd1, 0x0b, 0x5d, 0x53, 0xf8, 0x38,
+	0xa4, 0x51, 0x14, 0x44, 0xfe, 0x3d, 0xee, 0xb9, 0xce, 0x60, 0xfc, 0xd2, 0xd1, 0xcb, 0x39, 0x9e,
+	0xa0, 0x13, 0xc6, 0x37, 0x94, 0x18, 0xd0, 0xc8, 0x70, 0x05, 0x1e, 0x98, 0x8d, 0xcd, 0xd6, 0xaa,
+	0x2a, 0xe4, 0x09, 0xd4, 0x33, 0xa4, 0xeb, 0x4e, 0x1d, 0xbd, 0x62, 0xd6, 0x37, 0x5b, 0xab, 0xd2,
+	0x45, 0x41, 0x89, 0x09, 0x90, 0x7d, 0x9f, 0x4c, 0x9d, 0xee, 0xc0, 0xd5, 0xab, 0xca, 0xa1, 0x89,
+	0xa0, 0xb3, 0x10, 0x0b, 0x6c, 0xe8, 0x4c, 0x2f, 0x3d, 0x57, 0xaf, 0x29, 0x6c, 0x28, 0xf3, 0xd6,
+	0x89, 0xa1, 0xd6, 0x93, 0x4f, 0x33, 0x59, 0x42, 0x55, 0x5e, 0x7f, 0xf2, 0xec, 0x61, 0x8f, 0x47,
+	0x1e, 0x15, 0xd3, 0x7e, 0xe8, 0x76, 0x15, 0x9e, 0xce, 0xeb, 0x32, 0x80, 0x6a, 0xf9, 0x92, 0x71,
+	0x41, 0x12, 0x38, 0x9e, 0x60, 0xb2, 0xc6, 0xa4, 0x78, 0x59, 0xce, 0x1e, 0x1c, 0xe5, 0x5c, 0xc0,
+	0x67, 0x0f, 0x27, 0xe4, 0xf9, 0xfd, 0x51, 0x03, 0xf2, 0x66, 0xbc, 0xc9, 0xf3, 0xbd, 0x3f, 0xfa,
+	0xdf, 0x0b, 0x63, 0x7e, 0xf9, 0x4e, 0x5c, 0xa5, 0xa7, 0xdb, 0xba, 0xfd, 0xab, 0x55, 0xba, 0xbd,
+	0x6b, 0x69, 0xbf, 0xde, 0xb5, 0xb4, 0x3f, 0xef, 0x5a, 0xa5, 0x5f, 0xfe, 0x6e, 0x69, 0xdf, 0xd4,
+	0x0b, 0xea, 0xac, 0x26, 0x57, 0x9f, 0xff, 0x13, 0x00, 0x00, 0xff, 0xff, 0xc6, 0x5d, 0x63, 0x41,
+	0x46, 0x07, 0x00, 0x00,
 }

--- a/protocol/driver.proto
+++ b/protocol/driver.proto
@@ -2,6 +2,7 @@ syntax = "proto3";
 package gopkg.in.bblfsh.sdk.v2.protocol;
 
 import "github.com/gogo/protobuf/gogoproto/gogo.proto";
+import "google/protobuf/timestamp.proto";
 
 option (gogoproto.protosizer_all) = true;
 option (gogoproto.sizer_all) = false;
@@ -12,47 +13,96 @@ option go_package = "protocol";
 
 // ParseRequest is a request to parse a file and get its UAST.
 message ParseRequest {
-	// Content stores the content of a source file. Required.
-	string content  = 1;
-	// Language can be set optionally to disable automatic language detection.
-	string language = 2;
-	// Filename can be set optionally to assist automatic language detection.
-	string filename = 3;
-	// Mode sets a transformation pipeline used for UAST.
-	Mode   mode = 4;
+    // Content stores the content of a source file. Required.
+    string content  = 1;
+    // Language can be set optionally to disable automatic language detection.
+    string language = 2;
+    // Filename can be set optionally to assist automatic language detection.
+    string filename = 3;
+    // Mode sets a transformation pipeline used for UAST.
+    Mode   mode = 4;
 }
 
 enum Mode {
-	// DefaultMode selects the transformation mode that is considered to produce UAST of the best quality.
-	DEFAULT_MODE = 0x0 [(gogoproto.enumvalue_customname) = "DefaultMode"];
-	// Native disables any UAST transformations and emits a native language AST as returned by the parser.
-	NATIVE       = 0x1 [(gogoproto.enumvalue_customname) = "Native"];
-	// Preprocessed runs only basic transformation over native AST (normalize positional info, type fields).
-	PREPROCESSED = 0x2 [(gogoproto.enumvalue_customname) = "Preprocessed"];
-	// Annotated UAST is based on native AST, but provides role annotations for nodes.
-	ANNOTATED    = 0x4 [(gogoproto.enumvalue_customname) = "Annotated"];
-	// Semantic UAST normalizes native AST nodes to a unified structure where possible.
-	SEMANTIC     = 0x8 [(gogoproto.enumvalue_customname) = "Semantic"];
+    // DefaultMode selects the transformation mode that is considered to produce UAST of the best quality.
+    DEFAULT_MODE = 0x0 [(gogoproto.enumvalue_customname) = "DefaultMode"];
+    // Native disables any UAST transformations and emits a native language AST as returned by the parser.
+    NATIVE       = 0x1 [(gogoproto.enumvalue_customname) = "Native"];
+    // Preprocessed runs only basic transformation over native AST (normalize positional info, type fields).
+    PREPROCESSED = 0x2 [(gogoproto.enumvalue_customname) = "Preprocessed"];
+    // Annotated UAST is based on native AST, but provides role annotations for nodes.
+    ANNOTATED    = 0x4 [(gogoproto.enumvalue_customname) = "Annotated"];
+    // Semantic UAST normalizes native AST nodes to a unified structure where possible.
+    SEMANTIC     = 0x8 [(gogoproto.enumvalue_customname) = "Semantic"];
 }
 
 // ParseResponse is the reply to ParseRequest.
 message ParseResponse {
-	// UAST is a binary encoding of the resulting UAST.
-	bytes  uast = 1;
-	// Language that was automatically detected.
-	string language = 2;
-	// Errors is a list of parsing errors.
-	// Only set if parser was able to return a response. Otherwise gRPC error codes are used.
-	repeated ParseError errors = 3;
+    // UAST is a binary encoding of the resulting UAST.
+    bytes  uast = 1;
+    // Language that was automatically detected.
+    string language = 2;
+    // Errors is a list of parsing errors.
+    // Only set if parser was able to return a response. Otherwise gRPC error codes are used.
+    repeated ParseError errors = 3;
 }
 
 message ParseError {
-	// Text is an error message.
-	string text = 1;
+    // Text is an error message.
+    string text = 1;
 }
 
 service Driver {
-	// Parse returns an UAST for a given source file.
-	rpc Parse (ParseRequest) returns (ParseResponse);
+    // Parse returns an UAST for a given source file.
+    rpc Parse (ParseRequest) returns (ParseResponse);
 }
 
+message Version {
+    string version = 1;
+    google.protobuf.Timestamp build = 2 [(gogoproto.stdtime) = true, (gogoproto.nullable) = false];
+}
+
+enum DevelopmentStatus {
+    DEV_INACTIVE = 0 [(gogoproto.enumvalue_customname) = "Inactive"];
+    DEV_PLANNING = 1 [(gogoproto.enumvalue_customname) = "Planning"];
+    DEV_PREALPHA = 2 [(gogoproto.enumvalue_customname) = "PreAlpha"];
+    DEV_ALPHA    = 3 [(gogoproto.enumvalue_customname) = "Alpha"];
+    DEV_BETA     = 4 [(gogoproto.enumvalue_customname) = "Beta"];
+    DEV_STABLE   = 5 [(gogoproto.enumvalue_customname) = "Stable"];
+    DEV_MATURE   = 6 [(gogoproto.enumvalue_customname) = "Mature"];
+}
+
+message Manifest {
+    // Name is a human-readable language or driver name.
+    string name     = 1;
+    // Language is a Babelfish language identifier.
+    string language = 2;
+    // Aliases is a list of alternative language identifiers from Enry/Linguist.
+    repeated string aliases = 3;
+    // Version of the language driver.
+    Version version = 4;
+    // Status of the driver development.
+    DevelopmentStatus status = 5;
+    // Features this driver supports.
+    repeated string features = 6;
+}
+
+message VersionRequest {}
+
+message VersionResponse {
+    Version version = 1;
+}
+
+message SupportedLanguagesRequest {}
+
+message SupportedLanguagesResponse {
+    // Languages is a list of driver manifests for each language supported by the server.
+    repeated Manifest languages = 1;
+}
+
+service DriverHost {
+    // ServerVersion returns version information of this server.
+    rpc ServerVersion(VersionRequest) returns (VersionResponse);
+    // SupportedLanguages returns a list of languages supported by the server.
+    rpc SupportedLanguages (SupportedLanguagesRequest) returns (SupportedLanguagesResponse);
+}


### PR DESCRIPTION
This change defines a v2 endpoint for application version and the list of supported languages. It will finally allow moving https://github.com/bblfsh/bblfshd/pull/210 forward.

As a part of the change, define language aliases field in the driver manifest. This adds SDK support for https://github.com/bblfsh/bblfshd/issues/263.

The change is backward-compatible in the sense that it won't disable v1 language API in drivers, allowing to use them with older `bblfshd` versions.

But it also includes one breaking change for drivers. The internal driver interface has changed, thus drivers that declare a custom implementation would require few small changes. Note, however, that this is only true for drivers with custom implementations, and for now it only includes Go that is compiled directly into the driver server (as opposed to a separate binary with stdin/stdout pipes). Every other driver uses SDK to set up the server, thus requires no changes.

Regarding the language protocol itself, it only defines a few commonly used fields from the driver manifest, instead of all of them as defined by SDK. This can be changed later to add more fields to the protocol as needed.

Signed-off-by: Denys Smirnov <denys@sourced.tech>