### PR TITLE
Expose positional index to use in libuast

### DIFF
--- a/uast/transformer/positioner/positions.go
+++ b/uast/transformer/positioner/positions.go
@@ -1,6 +1,7 @@
 package positioner
 
 import (
+	"errors"
 	"fmt"
 	"sort"
 	"unicode/utf16"
@@ -41,17 +42,12 @@ func FromUTF16Offset() Positioner {
 // The transformation should be initialized with the source code by calling OnCode.
 type Positioner struct {
 	unicode bool
-	method  func(*positionIndex, *uast.Position) error
+	method  func(*Index, *uast.Position) error
 }
 
 // OnCode uses the source code to update positional information of UAST nodes.
 func (t Positioner) OnCode(code string) transformer.Transformer {
-	var idx *positionIndex
-	if t.unicode {
-		idx = newPositionIndexUnicode([]byte(code))
-	} else {
-		idx = newPositionIndex([]byte(code))
-	}
+	idx := NewIndex([]byte(code), &IndexOptions{Unicode: t.unicode})
 	return transformer.TransformObjFunc(func(o nodes.Object) (nodes.Object, bool, error) {
 		pos := uast.AsPosition(o)
 		if pos == nil {
@@ -70,7 +66,7 @@ func (t Positioner) OnCode(code string) transformer.Transformer {
 	})
 }
 
-func fromLineCol(idx *positionIndex, pos *uast.Position) error {
+func fromLineCol(idx *Index, pos *uast.Position) error {
 	offset, err := idx.Offset(int(pos.Line), int(pos.Col))
 	if err != nil {
 		return err
@@ -79,7 +75,7 @@ func fromLineCol(idx *positionIndex, pos *uast.Position) error {
 	return nil
 }
 
-func fromOffset(idx *positionIndex, pos *uast.Position) error {
+func fromOffset(idx *Index, pos *uast.Position) error {
 	line, col, err := idx.LineCol(int(pos.Offset))
 	if err != nil {
 		return err
@@ -89,7 +85,7 @@ func fromOffset(idx *positionIndex, pos *uast.Position) error {
 	return nil
 }
 
-func fromUnicodeOffset(idx *positionIndex, pos *uast.Position) error {
+func fromUnicodeOffset(idx *Index, pos *uast.Position) error {
 	off, err := idx.RuneOffset(int(pos.Offset))
 	if err != nil {
 		return err
@@ -98,7 +94,7 @@ func fromUnicodeOffset(idx *positionIndex, pos *uast.Position) error {
 	return fromOffset(idx, pos)
 }
 
-func fromUTF16Offset(idx *positionIndex, pos *uast.Position) error {
+func fromUTF16Offset(idx *Index, pos *uast.Position) error {
 	off, err := idx.UTF16Offset(int(pos.Offset))
 	if err != nil {
 		return err
@@ -125,14 +121,31 @@ type runeSpan struct {
 	numRunes int // number of runes in this span
 }
 
-type positionIndex struct {
+// Index is a positional index.
+type Index struct {
 	offsetByLine []int
-	spans        []runeSpan
+	spans        []runeSpan // if nil, multi-byte rune indexing is disabled
 	size         int
 }
 
-func newPositionIndex(data []byte) *positionIndex {
-	idx := &positionIndex{
+// IndexOptions is a set of options for positional index.
+type IndexOptions struct {
+	// Unicode flag controls if an index is build to accept UTF-8/UTF-16 rune offsets in
+	// addition to byte offsets.
+	// If the flag is not set, RuneOffset and UTF16Offset will always fail with an error.
+	Unicode bool
+}
+
+// NewIndex creates a new positional index.
+// If opt == nil, all options default to their zero values.
+func NewIndex(data []byte, opt *IndexOptions) *Index {
+	if opt == nil {
+		opt = &IndexOptions{}
+	}
+	if opt.Unicode {
+		return newIndexUnicode(data)
+	}
+	idx := &Index{
 		size: len(data),
 	}
 	idx.addLineOffset(0)
@@ -144,9 +157,10 @@ func newPositionIndex(data []byte) *positionIndex {
 	return idx
 }
 
-func newPositionIndexUnicode(data []byte) *positionIndex {
-	idx := &positionIndex{
-		size: len(data),
+func newIndexUnicode(data []byte) *Index {
+	idx := &Index{
+		size:  len(data),
+		spans: []runeSpan{}, // indicates that unicode index is enabled
 	}
 	idx.addLineOffset(0)
 
@@ -200,13 +214,13 @@ func newPositionIndexUnicode(data []byte) *positionIndex {
 	return idx
 }
 
-func (idx *positionIndex) addLineOffset(offset int) {
+func (idx *Index) addLineOffset(offset int) {
 	idx.offsetByLine = append(idx.offsetByLine, offset)
 }
 
 // LineCol returns a one-based line and col given a zero-based byte offset.
 // It returns an error if the given offset is out of bounds.
-func (idx *positionIndex) LineCol(offset int) (int, int, error) {
+func (idx *Index) LineCol(offset int) (int, int, error) {
 	var (
 		minOffset = 0
 		maxOffset = idx.size
@@ -230,7 +244,7 @@ func (idx *positionIndex) LineCol(offset int) (int, int, error) {
 
 // Offset returns a zero-based byte offset given a one-based line and column.
 // It returns an error if the given line and column are out of bounds.
-func (idx *positionIndex) Offset(line, col int) (int, error) {
+func (idx *Index) Offset(line, col int) (int, error) {
 	var (
 		minLine = 1
 		maxLine = len(idx.offsetByLine)
@@ -265,7 +279,10 @@ func (idx *positionIndex) Offset(line, col int) (int, error) {
 }
 
 // RuneOffset returns a zero-based byte offset given a zero-based Unicode character offset.
-func (idx *positionIndex) RuneOffset(offset int) (int, error) {
+func (idx *Index) RuneOffset(offset int) (int, error) {
+	if idx.spans == nil {
+		return 0, errors.New("unicode index is disabled")
+	}
 	var last int
 	if len(idx.spans) != 0 {
 		s := idx.spans[len(idx.spans)-1]
@@ -286,7 +303,10 @@ func (idx *positionIndex) RuneOffset(offset int) (int, error) {
 }
 
 // UTF16Offset returns a zero-based byte offset given a zero-based UTF-16 code point offset.
-func (idx *positionIndex) UTF16Offset(offset int) (int, error) {
+func (idx *Index) UTF16Offset(offset int) (int, error) {
+	if idx.spans == nil {
+		return 0, errors.New("unicode index is disabled")
+	}
 	var last int
 	if len(idx.spans) != 0 {
 		s := idx.spans[len(idx.spans)-1]

--- a/uast/transformer/positioner/positions_test.go
+++ b/uast/transformer/positioner/positions_test.go
@@ -128,7 +128,7 @@ a3`
 		{Offset: 12, Line: 3, Col: 3},
 	}
 
-	ind := newPositionIndex([]byte(source))
+	ind := NewIndex([]byte(source), nil)
 	for _, c := range cases {
 		t.Run("", func(t *testing.T) {
 			line, col, err := ind.LineCol(int(c.Offset))
@@ -179,7 +179,7 @@ a4`
 		{runeOff: 15, byteOff: 22, line: 4, col: 3},
 	}
 
-	ind := newPositionIndexUnicode([]byte(source))
+	ind := newIndexUnicode([]byte(source))
 	for _, c := range cases {
 		t.Run("", func(t *testing.T) {
 			off, err := ind.RuneOffset(c.runeOff)
@@ -232,7 +232,7 @@ a4`
 		{cpOff: 17, byteOff: 22, line: 4, col: 3},
 	}
 
-	ind := newPositionIndexUnicode([]byte(source))
+	ind := newIndexUnicode([]byte(source))
 	for _, c := range cases {
 		t.Run("", func(t *testing.T) {
 			off, err := ind.UTF16Offset(c.cpOff)


### PR DESCRIPTION
https://github.com/bblfsh/sdk/issues/382 requires exposing the positional index to be used in `libuast`/clients, so this change makes it public. Not sure why we had it private in the first place.

Signed-off-by: Denys Smirnov <denys@sourced.tech>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bblfsh/sdk/401)
<!-- Reviewable:end -->
