### PR TITLE
Support conversion to Unicode line-column positions

### DIFF
--- a/uast/transformer/positioner/positions.go
+++ b/uast/transformer/positioner/positions.go
@@ -241,7 +241,7 @@ func (idx *Index) offsetToLine(offset int) (int, error) {
 		return offset < idx.offsetByLine[i]
 	})
 	if line <= 0 || line > len(idx.offsetByLine) {
-		return 0, fmt.Errorf("offset not found in index: %d", offset)
+		return -1, fmt.Errorf("offset not found in index: %d", offset)
 	}
 	return line, nil
 }
@@ -263,12 +263,12 @@ func (idx *Index) checkByteOffset(offset int) error {
 func (idx *Index) LineCol(offset int) (int, int, error) {
 	err := idx.checkByteOffset(offset)
 	if err != nil && err != io.EOF {
-		return 0, 0, err
+		return -1, -1, err
 	}
 
 	line, err := idx.offsetToLine(offset)
 	if err != nil {
-		return 0, 0, err
+		return -1, -1, err
 	}
 	return line, offset - idx.lineOffset(line) + 1, nil
 }
@@ -299,7 +299,7 @@ func (idx *Index) Offset(line, col int) (int, error) {
 	}
 
 	if col < minCol || (maxCol > 0 && col-1 > maxCol) {
-		return 0, fmt.Errorf("column out of bounds: %d [%d, %d]", col, minCol, maxCol)
+		return -1, fmt.Errorf("column out of bounds: %d [%d, %d]", col, minCol, maxCol)
 	}
 	return lineOffset + col - 1, nil
 }
@@ -307,7 +307,7 @@ func (idx *Index) Offset(line, col int) (int, error) {
 // unicodeOffset returns a zero-based byte offset given a zero-based Unicode character offset or UTF-16 code unit offset.
 func (idx *Index) unicodeOffset(offset int, isUTF16 bool) (int, error) {
 	if idx.spans == nil {
-		return 0, errNoUnicodeIndex
+		return -1, errNoUnicodeIndex
 	}
 	var last int
 	if len(idx.spans) != 0 {
@@ -357,7 +357,7 @@ func (idx *Index) UTF16Offset(offset int) (int, error) {
 // toUnicodeOffset returns a zero-based Unicode character offset or a UTF-16 code unit given a zero-based byte offset.
 func (idx *Index) toUnicodeOffset(offset int, isUTF16 bool) (int, error) {
 	if idx.spans == nil {
-		return 0, errNoUnicodeIndex
+		return -1, errNoUnicodeIndex
 	}
 	err := idx.checkByteOffset(offset)
 	if err == io.EOF {
@@ -396,7 +396,7 @@ func (idx *Index) ToUTF16Offset(offset int) (int, error) {
 // toUnicodeLineCol returns a one-based Unicode character line-col or a UTF-16 code unit line-col given a zero-based byte offset.
 func (idx *Index) toUnicodeLineCol(offset int, isUTF16 bool) (int, int, error) {
 	if idx.spans == nil {
-		return 0, 0, errNoUnicodeIndex
+		return -1, -1, errNoUnicodeIndex
 	}
 	err := idx.checkByteOffset(offset)
 	if err != nil && err != io.EOF {

--- a/uast/transformer/positioner/positions.go
+++ b/uast/transformer/positioner/positions.go
@@ -258,7 +258,7 @@ func (idx *Index) checkByteOffset(offset int) error {
 	return nil
 }
 
-// LineCol returns a one-based line and col given a zero-based byte offset.
+// LineCol returns a one-based line and one-based column offset given a zero-based byte offset within a file.
 // It returns an error if the given offset is out of bounds.
 func (idx *Index) LineCol(offset int) (int, int, error) {
 	err := idx.checkByteOffset(offset)
@@ -282,7 +282,7 @@ func (idx *Index) checkLine(line int) error {
 	return nil
 }
 
-// Offset returns a zero-based byte offset given a one-based line and column.
+// Offset returns a zero-based byte offset within a file given a one-based line and one-based column offset.
 // It returns an error if the given line and column are out of bounds.
 func (idx *Index) Offset(line, col int) (int, error) {
 	if err := idx.checkLine(line); err != nil {
@@ -304,7 +304,8 @@ func (idx *Index) Offset(line, col int) (int, error) {
 	return lineOffset + col - 1, nil
 }
 
-// unicodeOffset returns a zero-based byte offset given a zero-based Unicode character offset or UTF-16 code unit offset.
+// unicodeOffset returns a zero-based byte offset within a file given a zero-based Unicode character offset or
+// UTF-16 code unit offset within a file.
 func (idx *Index) unicodeOffset(offset int, isUTF16 bool) (int, error) {
 	if idx.spans == nil {
 		return -1, errNoUnicodeIndex
@@ -344,31 +345,31 @@ func (idx *Index) unicodeOffset(offset int, isUTF16 bool) (int, error) {
 	return s.byteOff + s.runeSize8*(offset-s.firstRuneInd), nil
 }
 
-// FromRuneOffset returns a zero-based byte offset given a zero-based Unicode character offset.
+// FromRuneOffset returns a zero-based byte offset given a zero-based Unicode character offset within a file.
 func (idx *Index) FromRuneOffset(offset int) (int, error) {
 	return idx.unicodeOffset(offset, false)
 }
 
-// RuneOffset returns a zero-based byte offset given a zero-based Unicode character offset.
+// RuneOffset returns a zero-based byte offset given a zero-based Unicode character offset within a file.
 //
 // Deprecated: use FromRuneOffset.
 func (idx *Index) RuneOffset(offset int) (int, error) {
 	return idx.unicodeOffset(offset, false)
 }
 
-// FromUTF16Offset returns a zero-based byte offset given a zero-based UTF-16 code unit offset.
+// FromUTF16Offset returns a zero-based byte offset given a zero-based UTF-16 code unit offset within a file.
 func (idx *Index) FromUTF16Offset(offset int) (int, error) {
 	return idx.unicodeOffset(offset, true)
 }
 
-// UTF16Offset returns a zero-based byte offset given a zero-based UTF-16 code unit offset.
+// UTF16Offset returns a zero-based byte offset given a zero-based UTF-16 code unit offset within a file.
 //
 // Deprecated: use FromUTF16Offset
 func (idx *Index) UTF16Offset(offset int) (int, error) {
 	return idx.unicodeOffset(offset, true)
 }
 
-// toUnicodeOffset returns a zero-based Unicode character offset or a UTF-16 code unit given a zero-based byte offset.
+// toUnicodeOffset returns a zero-based Unicode character offset or a UTF-16 code unit offset given a zero-based byte offset within a file.
 func (idx *Index) toUnicodeOffset(offset int, isUTF16 bool) (int, error) {
 	if idx.spans == nil {
 		return -1, errNoUnicodeIndex
@@ -397,17 +398,18 @@ func (idx *Index) toUnicodeOffset(offset int, isUTF16 bool) (int, error) {
 	return s.firstRuneInd + (offset-s.byteOff)/s.runeSize8, nil
 }
 
-// ToRuneOffset returns a zero-based Unicode character offset given a zero-based byte offset.
+// ToRuneOffset returns a zero-based Unicode character offset given a zero-based byte offset within a file.
 func (idx *Index) ToRuneOffset(offset int) (int, error) {
 	return idx.toUnicodeOffset(offset, false)
 }
 
-// ToUTF16Offset returns a zero-based UTF-16 code unit offset given a zero-based byte offset.
+// ToUTF16Offset returns a zero-based UTF-16 code unit offset given a zero-based byte offset within a file.
 func (idx *Index) ToUTF16Offset(offset int) (int, error) {
 	return idx.toUnicodeOffset(offset, true)
 }
 
-// toUnicodeLineCol returns a one-based Unicode character line-col or a UTF-16 code unit line-col given a zero-based byte offset.
+// toUnicodeLineCol returns a one-based line and one-based column in Unicode characters or a UTF-16 code units given a
+// zero-based byte offset within a file.
 func (idx *Index) toUnicodeLineCol(offset int, isUTF16 bool) (int, int, error) {
 	if idx.spans == nil {
 		return -1, -1, errNoUnicodeIndex
@@ -458,13 +460,13 @@ func (idx *Index) toUnicodeLineCol(offset int, isUTF16 bool) (int, int, error) {
 	return line, col, nil
 }
 
-// ToUnicodeLineCol returns a one-based line and col in Unicode characters given a zero-based byte offset.
+// ToUnicodeLineCol returns a one-based line and one-based col in Unicode characters given a zero-based byte offset within a file.
 // It returns an error if the given offset is out of bounds.
 func (idx *Index) ToUnicodeLineCol(offset int) (int, int, error) {
 	return idx.toUnicodeLineCol(offset, false)
 }
 
-// ToUTF16LineCol returns a one-based line and col in UTF-16 code units given a zero-based byte offset.
+// ToUTF16LineCol returns a one-based line and one-based col in UTF-16 code units given a zero-based byte offset within a file.
 // It returns an error if the given offset is out of bounds.
 func (idx *Index) ToUTF16LineCol(offset int) (int, int, error) {
 	return idx.toUnicodeLineCol(offset, true)

--- a/uast/transformer/positioner/positions.go
+++ b/uast/transformer/positioner/positions.go
@@ -91,7 +91,7 @@ func fromOffset(idx *Index, pos *uast.Position) error {
 }
 
 func fromUnicodeOffset(idx *Index, pos *uast.Position) error {
-	off, err := idx.RuneOffset(int(pos.Offset))
+	off, err := idx.FromRuneOffset(int(pos.Offset))
 	if err != nil {
 		return err
 	}
@@ -100,7 +100,7 @@ func fromUnicodeOffset(idx *Index, pos *uast.Position) error {
 }
 
 func fromUTF16Offset(idx *Index, pos *uast.Position) error {
-	off, err := idx.UTF16Offset(int(pos.Offset))
+	off, err := idx.FromUTF16Offset(int(pos.Offset))
 	if err != nil {
 		return err
 	}
@@ -344,12 +344,26 @@ func (idx *Index) unicodeOffset(offset int, isUTF16 bool) (int, error) {
 	return s.byteOff + s.runeSize8*(offset-s.firstRuneInd), nil
 }
 
+// FromRuneOffset returns a zero-based byte offset given a zero-based Unicode character offset.
+func (idx *Index) FromRuneOffset(offset int) (int, error) {
+	return idx.unicodeOffset(offset, false)
+}
+
 // RuneOffset returns a zero-based byte offset given a zero-based Unicode character offset.
+//
+// Deprecated: use FromRuneOffset.
 func (idx *Index) RuneOffset(offset int) (int, error) {
 	return idx.unicodeOffset(offset, false)
 }
 
+// FromUTF16Offset returns a zero-based byte offset given a zero-based UTF-16 code unit offset.
+func (idx *Index) FromUTF16Offset(offset int) (int, error) {
+	return idx.unicodeOffset(offset, true)
+}
+
 // UTF16Offset returns a zero-based byte offset given a zero-based UTF-16 code unit offset.
+//
+// Deprecated: use FromUTF16Offset
 func (idx *Index) UTF16Offset(offset int) (int, error) {
 	return idx.unicodeOffset(offset, true)
 }

--- a/uast/transformer/positioner/positions_test.go
+++ b/uast/transformer/positioner/positions_test.go
@@ -198,7 +198,7 @@ a4`
 	ind := newIndexUnicode([]byte(source))
 	for _, c := range cases {
 		t.Run("", func(t *testing.T) {
-			off, err := ind.RuneOffset(c.runeOff)
+			off, err := ind.FromRuneOffset(c.runeOff)
 			require.NoError(t, err)
 			require.Equal(t, c.byteOff, off)
 
@@ -262,7 +262,7 @@ a4`
 	ind := newIndexUnicode([]byte(source))
 	for _, c := range cases {
 		t.Run("", func(t *testing.T) {
-			off, err := ind.UTF16Offset(c.cuOff)
+			off, err := ind.FromUTF16Offset(c.cuOff)
 			require.NoError(t, err)
 			require.Equal(t, c.byteOff, off)
 

--- a/uast/transformer/positioner/positions_test.go
+++ b/uast/transformer/positioner/positions_test.go
@@ -107,6 +107,21 @@ func TestFillOffsetEmptyFile(t *testing.T) {
 	require.Equal(expected, out)
 }
 
+func TestPosIndexSpans(t *testing.T) {
+	const source = `line1
+𝓏𝓏2
+ё3
+a4`
+	ind := NewIndex([]byte(source), &IndexOptions{Unicode: true})
+	require.Equal(t, []runeSpan{
+		{firstRuneInd: 0, firstUTF16Ind: 0, byteOff: 0, runeSize8: 1, runeSize16: 1, numRunes: 6},
+		{firstRuneInd: 6, firstUTF16Ind: 6, byteOff: 6, runeSize8: 4, runeSize16: 2, numRunes: 2},
+		{firstRuneInd: 8, firstUTF16Ind: 10, byteOff: 14, runeSize8: 1, runeSize16: 1, numRunes: 2},
+		{firstRuneInd: 10, firstUTF16Ind: 12, byteOff: 16, runeSize8: 2, runeSize16: 1, numRunes: 1},
+		{firstRuneInd: 11, firstUTF16Ind: 13, byteOff: 18, runeSize8: 1, runeSize16: 1, numRunes: 4},
+	}, ind.spans)
+}
+
 func TestPosIndex(t *testing.T) {
 	// Verify that a multi-byte Unicode rune does not displace offsets after
 	// its occurrence in the input. Test few other simple cases as well.


### PR DESCRIPTION
Support conversions from byte offset to Unicode/UTF-16 byte line-column pairs. Also, refactor the code for consistency and add more test cases.

This allows using positional info generated by Babelfish to calculate Unicode positions used in code editors.

Required by https://github.com/bblfsh/libuast/issues/102.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bblfsh/sdk/405)
<!-- Reviewable:end -->
