### PR TITLE
Implement node children iterator

### DIFF
--- a/uast/nodes/iter_test.go
+++ b/uast/nodes/iter_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/bblfsh/sdk/v3/uast/nodes"
+	"github.com/stretchr/testify/require"
 )
 
 func TestIterPreOrder(t *testing.T) {
@@ -22,7 +23,7 @@ func TestIterPreOrder(t *testing.T) {
 		b,
 	}
 	if !nodes.Equal(nodes.Array(exp), nodes.Array(got)) {
-		t.Fatalf("wrong order: %v", got)
+		require.Equal(t, nodes.Array(exp), nodes.Array(got))
 	}
 }
 
@@ -42,7 +43,7 @@ func TestIterPostOrder(t *testing.T) {
 		root,
 	}
 	if !nodes.Equal(nodes.Array(exp), nodes.Array(got)) {
-		t.Fatalf("wrong order: %v", got)
+		require.Equal(t, nodes.Array(exp), nodes.Array(got))
 	}
 }
 
@@ -62,7 +63,7 @@ func TestIterLevelOrder(t *testing.T) {
 		nodes.Int(1), nodes.Int(2),
 	}
 	if !nodes.Equal(nodes.Array(exp), nodes.Array(got)) {
-		t.Fatalf("wrong order: %v", got)
+		require.Equal(t, nodes.Array(exp), nodes.Array(got))
 	}
 }
 
@@ -83,11 +84,9 @@ func TestIterChildren(t *testing.T) {
 	got := allNodes(it)
 	exp := []nodes.Node{a, c}
 	if !nodes.Equal(nodes.Array(exp), nodes.Array(got)) {
-		t.Fatalf("wrong order: %v", got)
+		require.Equal(t, nodes.Array(exp), nodes.Array(got))
 	}
-	if n := nodes.ChildrenCount(root); n != len(exp) {
-		t.Fatalf("incorrect number of children: %d vs %d", n, len(exp))
-	}
+	require.Equal(t, nodes.ChildrenCount(root), len(exp))
 }
 
 func allNodes(it nodes.Iterator) []nodes.Node {

--- a/uast/nodes/iter_test.go
+++ b/uast/nodes/iter_test.go
@@ -66,6 +66,30 @@ func TestIterLevelOrder(t *testing.T) {
 	}
 }
 
+func TestIterChildren(t *testing.T) {
+	a := nodes.Object{
+		"k1": nodes.Int(1),
+		"k2": nodes.Array{nodes.Int(2)},
+	}
+	b := nodes.String("v")
+	c := nodes.Array{b}
+	root := nodes.Object{
+		"a": a,
+		"b": b,
+		"c": c,
+	}
+
+	it := nodes.NewIterator(root, nodes.ChildrenOrder)
+	got := allNodes(it)
+	exp := []nodes.Node{a, c}
+	if !nodes.Equal(nodes.Array(exp), nodes.Array(got)) {
+		t.Fatalf("wrong order: %v", got)
+	}
+	if n := nodes.ChildrenCount(root); n != len(exp) {
+		t.Fatalf("incorrect number of children: %d vs %d", n, len(exp))
+	}
+}
+
 func allNodes(it nodes.Iterator) []nodes.Node {
 	var out []nodes.Node
 	for it.Next() {

--- a/uast/query/iter.go
+++ b/uast/query/iter.go
@@ -14,9 +14,12 @@ const (
 	PreOrder      = nodes.PreOrder
 	PostOrder     = nodes.PostOrder
 	LevelOrder    = nodes.LevelOrder
-	PositionOrder = LevelOrder + iota + 1
+	ChildrenOrder = nodes.ChildrenOrder
+	PositionOrder = ChildrenOrder + iota + 1
 )
 
+// NewIterator creates a new iterator with a given order.
+// It's an extension of nodes.NewIterator that additionally supports PositionOrder.
 func NewIterator(root nodes.External, order IterOrder) Iterator {
 	if root == nil {
 		return Empty{}


### PR DESCRIPTION
This issue came up multiple times recently. Some client functions want to list all children nodes exactly one level deep. This code is not a one-liner since it requires the user to check the type of the node and indirect, if necessary. It also requires to flatten arrays for object fields.

Thus, it seems we need to add some helper to expose this functionality to clients. The best way, in my opinion, is to make a new iteration order.

This PR adds a new `Children` iteration order that does all required checks and indirections.

Also, while here, add documentation for types and methods in the package.

Signed-off-by: Denys Smirnov <denys@sourced.tech>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bblfsh/sdk/406)
<!-- Reviewable:end -->
