### PR TITLE
Fix issues with reflect-based node loader

### DIFF
--- a/uast/types_test.go
+++ b/uast/types_test.go
@@ -192,12 +192,8 @@ var casesToNode = []struct {
 				},
 			},
 			Array: []Any{
-				Identifier{Name: "a", GenNode: GenNode{
-					Positions: Positions{},
-				}},
-				String{Value: "a", GenNode: GenNode{
-					Positions: Positions{},
-				}},
+				Identifier{Name: "a"},
+				String{Value: "a"},
 			},
 		},
 		exp: nodes.Object{


### PR DESCRIPTION
Fix a few issues discovered in the reflect-based UAST node loader. Discovered when hacking on C++ ASTs:
* Properly load nodes into custom interface fields.
* Loader must not create empty struct and maps when the node is `nil`.
* Add a bit more docs and tests.

Signed-off-by: Denys Smirnov <denys@sourced.tech>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bblfsh/sdk/409)
<!-- Reviewable:end -->
