### PR TITLE
add Jenkinsfile template to the driver skeleton

### DIFF
--- a/build/sdk_update.go
+++ b/build/sdk_update.go
@@ -51,6 +51,7 @@ var managedFiles = map[string]bool{
 	"driver/main.go" + tplExt: true,
 	"driver/sdk_test.go":      true,
 	"driver/normalizer/transforms.go" + tplExt: true,
+	"Jenkinsfile" + tplExt:                     true,
 }
 
 type updater struct {

--- a/driver/server/server.go
+++ b/driver/server/server.go
@@ -135,13 +135,15 @@ func (s *Server) initializeFlags() {
 }
 
 func (s *Server) initializeLogger() error {
-	f := log.DefaultFactory
-	f.Level = *logs.level
-	f.Format = *logs.format
-	f.Fields = *logs.fields
+	// TODO(lwsanty): fix in go-log
+	log.DefaultFactory = &log.LoggerFactory{
+		Level:  *logs.level,
+		Format: *logs.format,
+		Fields: *logs.fields,
+	}
 
 	var err error
-	s.Logger, err = f.New(nil)
+	s.Logger, err = log.DefaultFactory.New(nil)
 	if err != nil {
 		return ErrInvalidLogger.Wrap(err)
 	}

--- a/etc/skeleton/Jenkinsfile.tpl
+++ b/etc/skeleton/Jenkinsfile.tpl
@@ -1,0 +1,68 @@
+pipeline {
+  agent {
+    kubernetes {
+      label '{{.Manifest.Language}}-driver-bblfsh-performance'
+      defaultContainer '{{.Manifest.Language}}-driver-bblfsh-performance'
+      yaml """
+spec:
+  nodeSelector:
+    srcd.host/type: jenkins-worker
+  affinity:
+    podAntiAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+      - labelSelector:
+          matchExpressions:
+          - key: jenkins
+            operator: In
+            values:
+            - slave
+        topologyKey: kubernetes.io/hostname
+  containers:
+  - name: {{.Manifest.Language}}-driver-bblfsh-performance
+    image: bblfsh/performance:latest
+    imagePullPolicy: Always
+    securityContext:
+      privileged: true
+    command:
+    - dockerd
+    tty: true
+"""
+    }
+  }
+  environment {
+    DRIVER_LANGUAGE = "{{.Manifest.Language}}"
+    DRIVER_REPO = "https://github.com/bblfsh/{{.Manifest.Language}}-driver.git"
+    DRIVER_SRC_FIXTURES = "${env.WORKSPACE}/fixtures"
+    BENCHMARK_FILE = "${env.WORKSPACE}/bench.log"
+    LOG_LEVEL = "debug"
+    PROM_ADDRESS = "http://prom-pushgateway-prometheus-pushgateway.monitoring.svc.cluster.local:9091"
+    PROM_JOB = "bblfsh_perfomance"
+  }
+  // TODO(lwsanty): https://github.com/src-d/infrastructure/issues/992
+  // this is polling for every 2 minutes
+  // however it's better to use trigger curl http://yourserver/jenkins/git/notifyCommit?url=<URL of the Git repository>
+  // https://kohsuke.org/2011/12/01/polling-must-die-triggering-jenkins-builds-from-a-git-hook/
+  // the problem is that it requires Jenkins to be accessible from the hook side
+  // probably Travis CI could trigger Jenkins after all unit tests have passed...
+  triggers { pollSCM('H/2 * * * *') }
+  stages {
+    stage('Run transformations benchmark') {
+      when { branch 'master' }
+      steps {
+        sh "set -o pipefail ; go test -run=NONE -bench=. ./driver/... | tee ${env.BENCHMARK_FILE}"
+      }
+    }
+    stage('Store transformations benchmark to prometheus') {
+      when { branch 'master' }
+      steps {
+        sh "/root/bblfsh-performance parse-and-store --language=${env.DRIVER_LANGUAGE} --commit=${env.GIT_COMMIT} --storage=prom ${env.BENCHMARK_FILE}"
+      }
+    }
+    stage('Run end-to-end benchmark') {
+      when { branch 'master' }
+      steps {
+        sh "/root/bblfsh-performance end-to-end --language=${env.DRIVER_LANGUAGE} --commit=${env.GIT_COMMIT} --docker-tag=latest --custom-driver=true --storage=prom ${env.DRIVER_SRC_FIXTURES}"
+      }
+    }
+  }
+}


### PR DESCRIPTION
As far as it was agreed that all supported drivers will be performance tested each time they receive commit in master, we came to conclusion that it would be more convenient to include Jenkinsfile template inside the drivers skeleton.
Type of benchmarks: transformations level and end-to-end level with bblfsh+driver installed setup
Test data: source code files inside the ./fixtures directory with a bench prefix

Signed-off-by: lwsanty <lwsanty@gmail.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bblfsh/sdk/414)
<!-- Reviewable:end -->
