### PR TITLE
Fixes ChildrenOrder

### DIFF
--- a/uast/nodes/iter.go
+++ b/uast/nodes/iter.go
@@ -229,13 +229,31 @@ func (it *levelOrderIter) Node() External {
 	return it.level[it.i]
 }
 
+func addUnfoldingArrays(nodes []External, n External) []External {
+	if n == nil || n.Kind().In(KindsValues) {
+		return nodes
+	}
+	switch n.Kind() {
+	case KindArray:
+		if m, ok := n.(ExternalArray); ok {
+			sz := m.Size()
+			for i := 0; i < sz; i++ {
+				if v := m.ValueAt(i); v != nil {
+					nodes = addUnfoldingArrays(nodes, v)
+				}
+			}
+		}
+	default:
+		nodes = append(nodes, n)
+	}
+
+	return nodes
+}
+
 func newChildrenIterator(n External) Iterator {
 	var nodes []External
 	eachChild(n, func(v External) {
-		if v == nil || v.Kind().In(KindsValues) {
-			return
-		}
-		nodes = append(nodes, v)
+		nodes = addUnfoldingArrays(nodes, v)
 	})
 	return newFixedIterator(nodes)
 }

--- a/uast/nodes/iter.go
+++ b/uast/nodes/iter.go
@@ -230,9 +230,6 @@ func (it *levelOrderIter) Node() External {
 }
 
 func addUnfoldingArrays(nodes []External, n External) []External {
-	if n == nil || n.Kind().In(KindsValues) {
-		return nodes
-	}
 	switch n.Kind() {
 	case KindArray:
 		if m, ok := n.(ExternalArray); ok {
@@ -243,10 +240,9 @@ func addUnfoldingArrays(nodes []External, n External) []External {
 				}
 			}
 		}
-	default:
+	case KindObject:
 		nodes = append(nodes, n)
 	}
-
 	return nodes
 }
 

--- a/uast/nodes/iter_test.go
+++ b/uast/nodes/iter_test.go
@@ -73,16 +73,20 @@ func TestIterChildren(t *testing.T) {
 		"k2": nodes.Array{nodes.Int(2)},
 	}
 	b := nodes.String("v")
-	c := nodes.Array{b}
+	c := nodes.Object{
+		"k3": b,
+	}
+	d := nodes.Array{c}
 	root := nodes.Object{
 		"a": a,
 		"b": b,
 		"c": c,
+		"d": d,
 	}
 
 	it := nodes.NewIterator(root, nodes.ChildrenOrder)
 	got := allNodes(it)
-	exp := []nodes.Node{a, c}
+	exp := []nodes.Node{a,c,c}
 	if !nodes.Equal(nodes.Array(exp), nodes.Array(got)) {
 		require.Equal(t, nodes.Array(exp), nodes.Array(got))
 	}


### PR DESCRIPTION
- [x] Adds unfolding of arrays in `ChildrenOrder`. Currently if we had a `root` with two children `son1` and `son2`, when calling `it = root.iterate(ChildrenOrder)`, we were returned an array `[son1, son2]` when calling `next(it)`. See #421 for context
- [x] Update tests for `ChildrenOrder`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bblfsh/sdk/422)
<!-- Reviewable:end -->
