### PR TITLE
Handles errors in the xpath queries gracefully

### DIFF
--- a/uast/nodes/iter.go
+++ b/uast/nodes/iter.go
@@ -222,6 +222,7 @@ func (it *levelOrderIter) Next() bool {
 	it.level = next
 	return len(it.level) > 0
 }
+
 func (it *levelOrderIter) Node() External {
 	if it.i >= len(it.level) {
 		return nil

--- a/uast/query/xpath/query_test.go
+++ b/uast/query/xpath/query_test.go
@@ -84,6 +84,10 @@ func TestFilter(t *testing.T) {
 	it, err = idx.Execute(root, "//Ident[@role = 'Invalid']")
 	require.NoError(t, err)
 	expect(t, it)
+
+	// Malformed query because of the position of the last *
+	it, err = idx.Execute(root, "//*[@role='Variable']*//Name")
+	require.Error(t, err)
 }
 
 func TestFilterObject(t *testing.T) {

--- a/uast/query/xpath/xpath.go
+++ b/uast/query/xpath/xpath.go
@@ -40,13 +40,13 @@ type xQuery struct {
 	exp *xpath.Expr
 }
 
-func (q *xQuery) Execute(root nodes.External) (_ query.Iterator, err error) {
+func (q *xQuery) Execute(root nodes.External) (_ query.Iterator, gerr error) {
 	// This workaround should be temporary. xpath library is not
 	// managing panics correctly (it should output a nice error instead)
-	// TODO fix the xpath library instead of recovering from the panic
+	// TODO(ncordon): fix the xpath library instead of recovering from the panic
 	defer func() {
 		if r := recover(); r != nil {
-			err = fmt.Errorf("Error executing the xPath query, maybe wrong syntax?")
+			gerr = fmt.Errorf("Error executing the xPath query, maybe wrong syntax? \nRecovered from %v", r)
 		}
 	}()
 

--- a/uast/query/xpath/xpath.go
+++ b/uast/query/xpath/xpath.go
@@ -40,7 +40,10 @@ type xQuery struct {
 	exp *xpath.Expr
 }
 
-func (q *xQuery) Execute(root nodes.External) (it query.Iterator, err error) {
+func (q *xQuery) Execute(root nodes.External) (_ query.Iterator, err error) {
+	// This workaround should be temporary. xpath library is not
+	// managing panics correctly (it should output a nice error instead)
+	// TODO fix the xpath library instead of recovering from the panic
 	defer func() {
 		if r := recover(); r != nil {
 			err = fmt.Errorf("Error executing the xPath query, maybe wrong syntax?")
@@ -74,8 +77,7 @@ func (q *xQuery) Execute(root nodes.External) (it query.Iterator, err error) {
 		return nil, fmt.Errorf("unsupported type: %T", val)
 	}
 
-	it = &valIterator{val: v}
-	return
+	return &valIterator{val: v}, nil
 }
 
 type valIterator struct {


### PR DESCRIPTION
Recovers from the panic, in case it is thrown when executing the xpath query and throws an error instead. When executing, in the `python-client` after this changes, the query:

```python
import bblfsh

client = bblfsh.BblfshClient("localhost:9432")
ctx = client.parse("./file.php")
ctx.filter("//*[@role='Variable']*//Name")
```

the python interpreter no longer explodes and we are shown a friendlier message:

```
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/usr/lib/python3.7/site-packages/bblfsh/result_context.py", line 34, in filter
    return NodeIterator(self.ctx.filter(query), self.ctx)
RuntimeError: Error executing the xPath query, maybe wrong syntax?
```

Since the modified method was already returning an error (but was not handling the panic and therefore Go killed the process of the client), this change should not carry cascade changes to the clients if they were already checking for an error when performing filter (`python-client` was catching the exception, for example).

Closes #424 

Signed-off-by: ncordon <nacho.cordon.castillo@gmail.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bblfsh/sdk/423)
<!-- Reviewable:end -->
