### PR TITLE
Clarify usage of Default role in switch statements

### DIFF
--- a/uast/role/role.go
+++ b/uast/role/role.go
@@ -266,6 +266,7 @@ const (
 	Case
 
 	// Default is a clause that is called when no other clause matches.
+	// For Switch statements, the node with the Default role must also have the Case role.
 	Default
 
 	// For is a loop with an initialization, a condition, an update and a body.


### PR DESCRIPTION
Currently, as noted in https://github.com/bblfsh/php-driver/pull/56#issuecomment-522348679, drivers use the `Default` role differently in switch statements: some include the `Case` role, while others omit it when the case is a `Default` one.

This PR clarifies the usage of `Default` and requires the `Case` role to be set as well for switch statements.

Signed-off-by: Denys Smirnov <denys@sourced.tech>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bblfsh/sdk/427)
<!-- Reviewable:end -->
