### PR TITLE
Turns encoding field into Encoding in bblfsh-sdk request

### DIFF
--- a/cmd/bblfsh-sdk/cmd/request.go
+++ b/cmd/bblfsh-sdk/cmd/request.go
@@ -20,7 +20,7 @@ type RequestCommand struct {
 
 type ParseRequest struct {
 	Content  string `json:"content"`
-	Encoding string `json:"encoding"`
+	Encoding string `json:"Encoding"`
 }
 
 func (r *RequestCommand) Execute(args []string) error {


### PR DESCRIPTION
`encoding` field of the payload generated by `bblfsh-sdk request` should be `Encoding` instead to not make drivers crash if we test them with that tool.

That would make the field match https://github.com/bblfsh/sdk/blob/77c81e6f6883d2aa9f57acfabd4a6099e8eac2ef/driver/native/native.go#L137

Signed-off-by: ncordon <nacho.cordon.castillo@gmail.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bblfsh/sdk/441)
<!-- Reviewable:end -->
