### PR TITLE
Pool of native drivers (prototype)

### DIFF
--- a/driver/driver.go
+++ b/driver/driver.go
@@ -32,6 +32,9 @@ var (
 
 	// ErrUnknownEncoding is returned for parse requests with a file content in a non-UTF8 encoding.
 	ErrUnknownEncoding = errors.NewKind("unknown source file encoding (expected UTF-8)")
+
+	// ErrDriverClosed is returned when Parse function was called after driver was closed.
+	ErrDriverClosed = errors.NewKind("driver has been closed")
 )
 
 // ErrMissingDriver indicates that a driver image for the given language

--- a/driver/impl.go
+++ b/driver/impl.go
@@ -10,14 +10,18 @@ import (
 	"github.com/bblfsh/sdk/v3/uast/nodes"
 )
 
-// NewDriver returns a new Driver instance based on the given ObjectToNode and list of transformers.
-func NewDriverFrom(d Native, m *manifest.Manifest, t Transforms) (DriverModule, error) {
-	if d == nil {
+// NewDriverFrom returns a new DriverModule instance based on
+// the given pool of native drivers, language manifest and list of transformers.
+func NewDriverFrom(ch chan Native, m *manifest.Manifest, t Transforms) (DriverModule, error) {
+	if ch == nil || len(ch) == 0 {
 		return nil, fmt.Errorf("no driver implementation")
-	} else if m == nil {
+	}
+
+	if m == nil {
 		return nil, fmt.Errorf("no manifest")
 	}
-	return &driverImpl{d: d, m: m, t: t}, nil
+
+	return &driverImpl{ch: ch, m: m, t: t, done: make(chan struct{})}, nil
 }
 
 // Driver implements a bblfsh driver, a driver is on charge of transforming a
@@ -25,21 +29,52 @@ func NewDriverFrom(d Native, m *manifest.Manifest, t Transforms) (DriverModule, 
 // `uast.ObjectToNode`` and a series of `tranformer.Transformer` are used.
 //
 // The `Parse` and `NativeParse` requests block the driver until the request is
-// done, since the communication with the native driver is a single-channel
-// synchronous communication over stdin/stdout.
+// done. The communication with the native driver is based on a buffer channel of drivers,
+// internally it allows number of concurrent requests equal to channel's size (by default - number of CPUs).
+// Communication with single driver is synchronous and goes over stdin/stdout.
 type driverImpl struct {
-	d Native
+	ch chan Native
 
-	m *manifest.Manifest
-	t Transforms
+	m    *manifest.Manifest
+	t    Transforms
+	done chan struct{}
 }
 
+// Start gets each driver from the channel, starts the process
+// and puts it back to the same buffer channel.
+// If any of processes fail on start,
+// the function tries to close all running drivers and return an error.
 func (d *driverImpl) Start() error {
-	return d.d.Start()
+	for i := 0; i < len(d.ch); i++ {
+		drv := <-d.ch
+		if err := drv.Start(); err != nil {
+			d.Close()
+			return err
+		}
+		d.ch <- drv
+	}
+	return nil
 }
 
+// Close tries to close all idle drivers.
+// If any of drivers fail on Close, the function returns the last received error.
 func (d *driverImpl) Close() error {
-	return d.d.Close()
+	select {
+	case <-d.done:
+		return nil
+
+	default:
+		close(d.done)
+
+		var last error
+		for i := 0; i < len(d.ch); i++ {
+			drv := <-d.ch
+			if err := drv.Close(); err != nil {
+				last = err
+			}
+		}
+		return last
+	}
 }
 
 // Parse process a protocol.ParseRequest, calling to the native driver. It a
@@ -52,25 +87,39 @@ func (d *driverImpl) Parse(rctx context.Context, src string, opts *ParseOptions)
 	if opts == nil {
 		opts = &ParseOptions{}
 	}
-	ast, err := d.d.Parse(ctx, src)
-	if err != nil {
-		if !ErrDriverFailure.Is(err) {
-			// all other errors are considered syntax errors
-			err = ErrSyntax.Wrap(err)
-		} else {
-			ast = nil
+
+	select {
+	case <-rctx.Done():
+		return nil, rctx.Err()
+
+	case <-d.done:
+		return nil, ErrDriverClosed.New()
+
+	case drv := <-d.ch: // get a native driver or wait on available one.
+		// put the driver back, when you're done.
+		defer func() { d.ch <- drv }()
+
+		ast, err := drv.Parse(ctx, src)
+		if err != nil {
+			if !ErrDriverFailure.Is(err) {
+				// all other errors are considered syntax errors
+				err = ErrSyntax.Wrap(err)
+			} else {
+				ast = nil
+			}
+			return ast, err
+		}
+		if opts.Language == "" {
+			opts.Language = d.m.Language
+		}
+
+		ast, err = d.t.Do(ctx, opts.Mode, src, ast)
+		if err != nil {
+			err = ErrTransformFailure.Wrap(err)
 		}
 		return ast, err
-	}
-	if opts.Language == "" {
-		opts.Language = d.m.Language
-	}
 
-	ast, err = d.t.Do(ctx, opts.Mode, src, ast)
-	if err != nil {
-		err = ErrTransformFailure.Wrap(err)
 	}
-	return ast, err
 }
 
 // Version returns driver version.

--- a/driver/server/server_test.go
+++ b/driver/server/server_test.go
@@ -23,7 +23,11 @@ func newDriver(path string) (*service, error) {
 	if err != nil {
 		return nil, err
 	}
-	d, err := driver.NewDriverFrom(native.NewDriverAt(path, native.UTF8), m, driver.Transforms{})
+
+	ch := make(chan driver.Native, 1)
+	ch <- native.NewDriverAt(path, native.UTF8)
+
+	d, err := driver.NewDriverFrom(ch, m, driver.Transforms{})
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Signed-off-by: kuba-- <kuba@sourced.tech>

This is the first draft/prototype which implements a pool of native drivers (parsers).
Instead of having just one native driver we handle a pool of concurrent drivers, so for each grpc.Parse request we can pull the driver, write request and put them back to the pool.
The pool of drivers was implemented as _buffered channel_.

This PR closes https://github.com/bblfsh/bblfshd/issues/321
and it's a part of epic: https://github.com/bblfsh/bblfshd/issues/313

Some design details you can find in doc: https://docs.google.com/document/d/1671ApmxFCOmerVKloVC6Q6j8BsJr8xZHbhuE40ZK-as/edit?pli=1#

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bblfsh/sdk/443)
<!-- Reviewable:end -->
